### PR TITLE
Removed debug URL in pages extension

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/admin/personaBar/scripts/Pages.js
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/admin/personaBar/scripts/Pages.js
@@ -4,7 +4,6 @@
 
     var config = cf.init();
     function loadScript() {
-        //var url = "http://localhost:8080/dist/pages-bundle.js"
         var url = "modules/dnn.pages/scripts/bundles/pages-bundle.js";
         $.ajax({
             dataType: "script",


### PR DESCRIPTION
There is no need for this JS comment in a production environment.