### PR TITLE
DNN-8941: packages names checks should be case insensitive.

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PageUrlsController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PageUrlsController.cs
@@ -190,7 +190,7 @@ namespace Dnn.PersonaBar.Pages.Components
                 }
                 else
                 {
-                    if (!tabUrl.Url.Equals("/" + urlPath, StringComparison.InvariantCultureIgnoreCase))
+                    if (!tabUrl.Url.Equals("/" + urlPath, StringComparison.OrdinalIgnoreCase))
                     {
                         //Change the original 200 url to a redirect
                         tabUrl.HttpStatus = "301";
@@ -314,7 +314,7 @@ namespace Dnn.PersonaBar.Pages.Components
 
                     path = path.Replace(Globals.AddHTTP(alias.HTTPAlias), "");
                     int status = 200;
-                    if (customPath != null && (string.Compare(customPath, path, StringComparison.InvariantCultureIgnoreCase) != 0))
+                    if (customPath != null && (string.Compare(customPath, path, StringComparison.OrdinalIgnoreCase) != 0))
                     {
                         //difference in custom/standard URL, so standard is 301
                         status = 301;
@@ -347,7 +347,7 @@ namespace Dnn.PersonaBar.Pages.Components
                         if (tab.TabName.Contains(" ") && friendlyUrlSettings.ReplaceSpaceWith != FriendlyUrlSettings.ReplaceSpaceWithNothing)
                         {
                             path = path.Replace(friendlyUrlSettings.ReplaceSpaceWith, String.Empty);
-                            if (customPath != null && string.Compare(customPath, path, StringComparison.InvariantCultureIgnoreCase) != 0)
+                            if (customPath != null && string.Compare(customPath, path, StringComparison.OrdinalIgnoreCase) != 0)
                             {
                                 AddUrlToList(tabs, portalId, -1, alias, urlLocale, path, String.Empty, (isRedirected) ? 301 : 200, isSystem, friendlyUrlSettings, null);
                             }
@@ -462,7 +462,7 @@ namespace Dnn.PersonaBar.Pages.Components
         {
             public int Compare(KeyValuePair<int, string> pair1, KeyValuePair<int, string> pair2)
             {
-                return String.Compare(pair1.Value, pair2.Value, StringComparison.InvariantCultureIgnoreCase);
+                return String.Compare(pair1.Value, pair2.Value, StringComparison.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
@@ -275,8 +275,8 @@ namespace Dnn.PersonaBar.Pages.Components
                                 !t.IsSystem &&
                                     ((string.IsNullOrEmpty(searchKey) && (t.ParentId == parentId))
                                         || (!string.IsNullOrEmpty(searchKey) &&
-                                                (t.TabName.IndexOf(searchKey, StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger
-                                                    || t.LocalizedTabName.IndexOf(searchKey, StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger)))
+                                                (t.TabName.IndexOf(searchKey, StringComparison.OrdinalIgnoreCase) > Null.NullInteger
+                                                    || t.LocalizedTabName.IndexOf(searchKey, StringComparison.OrdinalIgnoreCase) > Null.NullInteger)))
                         select t;
 
             return pages;
@@ -337,8 +337,8 @@ namespace Dnn.PersonaBar.Pages.Components
                                 !t.IsSystem &&
                                     (string.IsNullOrEmpty(searchKey)
                                         || (!string.IsNullOrEmpty(searchKey) &&
-                                                (t.TabName.IndexOf(searchKey, StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger
-                                                    || t.LocalizedTabName.IndexOf(searchKey, StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger)))
+                                                (t.TabName.IndexOf(searchKey, StringComparison.OrdinalIgnoreCase) > Null.NullInteger
+                                                    || t.LocalizedTabName.IndexOf(searchKey, StringComparison.OrdinalIgnoreCase) > Null.NullInteger)))
                         select t;
 
             if (!string.IsNullOrEmpty(pageType))
@@ -642,7 +642,7 @@ namespace Dnn.PersonaBar.Pages.Components
                 //get all terms info
                 var allTerms = new List<Term>();
                 var vocabularies = from v in vocabularyController.GetVocabularies()
-                                   where (v.ScopeType.ScopeType == "Portal" && v.ScopeId == tab.PortalID && !v.Name.Equals("Tags", StringComparison.InvariantCultureIgnoreCase))
+                                   where (v.ScopeType.ScopeType == "Portal" && v.ScopeId == tab.PortalID && !v.Name.Equals("Tags", StringComparison.OrdinalIgnoreCase))
                                    select v;
                 foreach (var v in vocabularies)
                 {
@@ -653,7 +653,7 @@ namespace Dnn.PersonaBar.Pages.Components
                 {
                     if (!string.IsNullOrEmpty(tag))
                     {
-                        var term = allTerms.FirstOrDefault(t => t.Name.Equals(tag, StringComparison.InvariantCultureIgnoreCase));
+                        var term = allTerms.FirstOrDefault(t => t.Name.Equals(tag, StringComparison.OrdinalIgnoreCase));
                         if (term == null)
                         {
                             var termId = termController.AddTerm(new Term(tag, string.Empty, vocabularyId));
@@ -671,7 +671,7 @@ namespace Dnn.PersonaBar.Pages.Components
             var defaultContainer = _defaultPortalThemeController.GetDefaultPortalContainer();
             if (pageSettings.ContainerSrc != null &&
                 pageSettings.ContainerSrc.Equals(defaultContainer,
-                StringComparison.InvariantCultureIgnoreCase))
+                StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
@@ -683,7 +683,7 @@ namespace Dnn.PersonaBar.Pages.Components
             var defaultSkin = _defaultPortalThemeController.GetDefaultPortalLayout();
             if (pageSettings.SkinSrc != null &&
                 pageSettings.SkinSrc.Equals(defaultSkin,
-                StringComparison.InvariantCultureIgnoreCase))
+                StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
@@ -1164,7 +1164,7 @@ namespace Dnn.PersonaBar.Pages.Components
         private void CopySourceTabProperties(TabInfo tab, TabInfo sourceTab)
         {
             var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
-            tab.SkinSrc = sourceTab.SkinSrc.Equals(portalSettings.DefaultPortalSkin, StringComparison.InvariantCultureIgnoreCase) ? string.Empty : sourceTab.SkinSrc;
+            tab.SkinSrc = sourceTab.SkinSrc.Equals(portalSettings.DefaultPortalSkin, StringComparison.OrdinalIgnoreCase) ? string.Empty : sourceTab.SkinSrc;
             tab.ContainerSrc = sourceTab.ContainerSrc;
             tab.IconFile = sourceTab.IconFile;
             tab.IconFileLarge = sourceTab.IconFileLarge;

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/TermHelper.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/TermHelper.cs
@@ -52,7 +52,7 @@ namespace Dnn.PersonaBar.Pages.Components
             //get all terms info
             var allTerms = new List<Term>();
             var vocabularies = from v in vocabularyController.GetVocabularies()
-                               where (v.ScopeType.ScopeType == "Portal" && v.ScopeId == tabPortalId && !v.Name.Equals("Tags", StringComparison.InvariantCultureIgnoreCase))
+                               where (v.ScopeType.ScopeType == "Portal" && v.ScopeId == tabPortalId && !v.Name.Equals("Tags", StringComparison.OrdinalIgnoreCase))
                                select v;
             foreach (var v in vocabularies)
             {
@@ -63,7 +63,7 @@ namespace Dnn.PersonaBar.Pages.Components
             {
                 if (!string.IsNullOrEmpty(tag))
                 {
-                    var term = allTerms.FirstOrDefault(t => t.Name.Equals(tag, StringComparison.InvariantCultureIgnoreCase));
+                    var term = allTerms.FirstOrDefault(t => t.Name.Equals(tag, StringComparison.OrdinalIgnoreCase));
                     if (term == null)
                     {
                         var termId = termController.AddTerm(new Term(tag, string.Empty, vocabularyId));

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Services/PagesController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Services/PagesController.cs
@@ -465,9 +465,9 @@ namespace Dnn.PersonaBar.Pages.Services
         public HttpResponseMessage GetThemeFiles(string themeName, ThemeLevel level)
         {
             var themeLayout = _themesController.GetLayouts(PortalSettings, level)
-                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == level);
+                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == level);
             var themeContainer = _themesController.GetContainers(PortalSettings, level)
-                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == level);
+                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == level);
 
             return Request.CreateResponse(HttpStatusCode.OK, new
             {
@@ -859,7 +859,7 @@ namespace Dnn.PersonaBar.Pages.Services
 
         //private bool IsDefaultLanguage(string cultureCode)
         //{
-        //    return string.Equals(cultureCode, PortalSettings.DefaultLanguage, StringComparison.InvariantCultureIgnoreCase);
+        //    return string.Equals(cultureCode, PortalSettings.DefaultLanguage, StringComparison.OrdinalIgnoreCase);
         //}
 
         //private bool IsLanguageEnabled(string cultureCode)

--- a/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Services/RecyclebinController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Services/RecyclebinController.cs
@@ -325,7 +325,7 @@ namespace Dnn.PersonaBar.Recyclebin.Services
         private bool UseDefaultSkin(TabInfo tab)
         {
             return !string.IsNullOrEmpty(tab.SkinSrc) &&
-                   tab.SkinSrc.Equals(PortalSettings.DefaultPortalSkin, StringComparison.InvariantCultureIgnoreCase);
+                   tab.SkinSrc.Equals(PortalSettings.DefaultPortalSkin, StringComparison.OrdinalIgnoreCase);
         }
 
         private ModuleItem ConvertToModuleItem(ModuleInfo mod)

--- a/src/Modules/Manage/Dnn.PersonaBar.Roles/Components/RolesController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Roles/Components/RolesController.cs
@@ -56,7 +56,7 @@ namespace Dnn.PersonaBar.Roles.Components
                 .Where(r => isAdmin || r.RoleID != portalSettings.AdministratorRoleId);
             if (!string.IsNullOrEmpty(keyword))
             {
-                roles = roles.Where(r => r.RoleName.IndexOf(keyword, StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger);
+                roles = roles.Where(r => r.RoleName.IndexOf(keyword, StringComparison.OrdinalIgnoreCase) > Null.NullInteger);
             }
 
             var roleInfos = roles as IList<RoleInfo> ?? roles.ToList();
@@ -87,7 +87,7 @@ namespace Dnn.PersonaBar.Roles.Components
 
             if (roleDto.Id == Null.NullInteger)
             {
-                if (RoleController.Instance.GetRole(portalSettings.PortalId, r => rolename.Equals(r.RoleName, StringComparison.InvariantCultureIgnoreCase)) == null)
+                if (RoleController.Instance.GetRole(portalSettings.PortalId, r => rolename.Equals(r.RoleName, StringComparison.OrdinalIgnoreCase)) == null)
                 {
                     RoleController.Instance.AddRole(role, assignExistUsers);
                     roleDto.Id = role.RoleID;
@@ -115,7 +115,7 @@ namespace Dnn.PersonaBar.Roles.Components
                         RoleController.Instance.UpdateRole(existingRole, assignExistUsers);
                     }
                 }
-                else if (RoleController.Instance.GetRole(portalSettings.PortalId, r => rolename.Equals(r.RoleName, StringComparison.InvariantCultureIgnoreCase) && r.RoleID != roleDto.Id) == null)
+                else if (RoleController.Instance.GetRole(portalSettings.PortalId, r => rolename.Equals(r.RoleName, StringComparison.OrdinalIgnoreCase) && r.RoleID != roleDto.Id) == null)
                 {
                     existingRole.RoleName = role.RoleName;
                     existingRole.Description = role.Description;

--- a/src/Modules/Manage/Dnn.PersonaBar.Roles/Services/RolesController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Roles/Services/RolesController.cs
@@ -264,7 +264,7 @@ namespace Dnn.PersonaBar.Roles.Services
                 if (!string.IsNullOrEmpty(keyword))
                 {
                     users =
-                        users.Where(u => u.FullName.StartsWith(keyword, StringComparison.InvariantCultureIgnoreCase))
+                        users.Where(u => u.FullName.StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
                             .ToList();
                 }
 

--- a/src/Modules/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Sites/Components/SitesController.cs
@@ -229,7 +229,7 @@ namespace Dnn.PersonaBar.Sites.Components
             };
 
             var filename = Globals.HostMapPath + request.FileName.Replace("/", @"\");
-            if (!filename.EndsWith(".template", StringComparison.InvariantCultureIgnoreCase))
+            if (!filename.EndsWith(".template", StringComparison.OrdinalIgnoreCase))
             {
                 filename += ".template";
             }
@@ -442,7 +442,7 @@ namespace Dnn.PersonaBar.Sites.Components
                 PortalAliasInfo portalAlias = null;
                 foreach (PortalAliasInfo alias in PortalAliasController.Instance.GetPortalAliases().Values)
                 {
-                    if (string.Equals(alias.HTTPAlias, strPortalAlias, StringComparison.InvariantCultureIgnoreCase))
+                    if (string.Equals(alias.HTTPAlias, strPortalAlias, StringComparison.OrdinalIgnoreCase))
                     {
                         portalAlias = alias;
                         break;

--- a/src/Modules/Manage/Dnn.PersonaBar.Themes/Components/ThemesController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Themes/Components/ThemesController.cs
@@ -132,7 +132,7 @@ namespace Dnn.PersonaBar.Themes.Components
                     fallbackSkin = IsFallbackContainer(themePath);
                 }
 
-                var strSkinType = themePath.IndexOf(Globals.HostMapPath, StringComparison.InvariantCultureIgnoreCase) != -1 ? "G" : "L";
+                var strSkinType = themePath.IndexOf(Globals.HostMapPath, StringComparison.OrdinalIgnoreCase) != -1 ? "G" : "L";
 
                 var canDeleteSkin = SkinController.CanDeleteSkin(themePath, portalSettings.HomeDirectoryMapPath);
                 var arrFiles = Directory.GetFiles(themePath, "*.ascx");
@@ -178,17 +178,17 @@ namespace Dnn.PersonaBar.Themes.Components
         public ThemeFileInfo GetThemeFile(PortalSettings portalSettings, string filePath, ThemeType type)
         {
             var themeName = SkinController.FormatSkinPath(filePath)
-                            .Substring(filePath.IndexOf("/", StringComparison.InvariantCultureIgnoreCase) + 1)
+                            .Substring(filePath.IndexOf("/", StringComparison.OrdinalIgnoreCase) + 1)
                             .Replace("/", string.Empty);
             var themeLevel = GetThemeLevel(filePath);
 
             var themeInfo = (type == ThemeType.Skin ? GetLayouts(portalSettings, ThemeLevel.All)
                                                     : GetContainers(portalSettings, ThemeLevel.All))
-                            .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == themeLevel);
+                            .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == themeLevel);
 
             if (themeInfo != null)
             {
-                return GetThemeFiles(portalSettings, themeInfo).FirstOrDefault(f => (f.Path + ".ascx").Equals(filePath, StringComparison.InvariantCultureIgnoreCase));
+                return GetThemeFiles(portalSettings, themeInfo).FirstOrDefault(f => (f.Path + ".ascx").Equals(filePath, StringComparison.OrdinalIgnoreCase));
             }
 
             return null;
@@ -240,7 +240,7 @@ namespace Dnn.PersonaBar.Themes.Components
         public void ApplyDefaultTheme(PortalSettings portalSettings, string themeName, ThemeLevel level)
         {
             var skin = GetLayouts(portalSettings, ThemeLevel.All)
-                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == level);
+                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == level);
             if (skin != null)
             {
                 var skinFile = GetThemeFiles(portalSettings, skin).FirstOrDefault(t => t.Path == skin.DefaultThemeFile);
@@ -251,7 +251,7 @@ namespace Dnn.PersonaBar.Themes.Components
             }
 
             var container = GetContainers(portalSettings, ThemeLevel.All)
-                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == level);
+                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == level);
             if (container != null)
             {
                 var containerFile = GetThemeFiles(portalSettings, container).FirstOrDefault(t => t.Path == container.DefaultThemeFile);
@@ -272,7 +272,7 @@ namespace Dnn.PersonaBar.Themes.Components
             var themePath = SkinController.FormatSkinSrc(themeFile.Path, portalSettings);
             var user = UserController.Instance.GetCurrentUserInfo();
 
-            if (!user.IsSuperUser && themePath.IndexOf("\\portals\\_default\\", StringComparison.InvariantCultureIgnoreCase) != Null.NullInteger)
+            if (!user.IsSuperUser && themePath.IndexOf("\\portals\\_default\\", StringComparison.OrdinalIgnoreCase) != Null.NullInteger)
             {
                 throw new SecurityException("NoPermission");
             }
@@ -291,7 +291,7 @@ namespace Dnn.PersonaBar.Themes.Components
             var themePath = Path.Combine(Globals.ApplicationMapPath, theme.Path);
             var user = UserController.Instance.GetCurrentUserInfo();
 
-            if (!user.IsSuperUser  && themePath.IndexOf("\\portals\\_default\\", StringComparison.InvariantCultureIgnoreCase) != Null.NullInteger)
+            if (!user.IsSuperUser  && themePath.IndexOf("\\portals\\_default\\", StringComparison.OrdinalIgnoreCase) != Null.NullInteger)
             {
                 throw new SecurityException("NoPermission");
             }
@@ -535,8 +535,8 @@ namespace Dnn.PersonaBar.Themes.Components
             var defaultFile = themeFiles.FirstOrDefault(i =>
             {
                 var fileName = Path.GetFileNameWithoutExtension(i);
-                return type == ThemeType.Skin ? DefaultLayoutNames.Contains(fileName, StringComparer.InvariantCultureIgnoreCase)
-                                              : DefaultContainerNames.Contains(fileName, StringComparer.InvariantCultureIgnoreCase);
+                return type == ThemeType.Skin ? DefaultLayoutNames.Contains(fileName, StringComparer.OrdinalIgnoreCase)
+                                              : DefaultContainerNames.Contains(fileName, StringComparer.OrdinalIgnoreCase);
             });
 
             if (string.IsNullOrEmpty(defaultFile))
@@ -681,13 +681,13 @@ namespace Dnn.PersonaBar.Themes.Components
                 strRootSkin = SkinController.RootContainer.ToLower();
             }
 
-            var strSkinType = themePath.IndexOf(Globals.HostMapPath, StringComparison.InvariantCultureIgnoreCase) != -1 ? "G" : "L";
-            if (themePath.IndexOf(portalSettings.HomeSystemDirectoryMapPath, StringComparison.InvariantCultureIgnoreCase) > -1)
+            var strSkinType = themePath.IndexOf(Globals.HostMapPath, StringComparison.OrdinalIgnoreCase) != -1 ? "G" : "L";
+            if (themePath.IndexOf(portalSettings.HomeSystemDirectoryMapPath, StringComparison.OrdinalIgnoreCase) > -1)
             {
                 strSkinType = "S";
             }
 
-            var strUrl = lowercasePath.Substring(filePath.IndexOf("\\" + strRootSkin + "\\", StringComparison.InvariantCultureIgnoreCase))
+            var strUrl = lowercasePath.Substring(filePath.IndexOf("\\" + strRootSkin + "\\", StringComparison.OrdinalIgnoreCase))
                         .Replace(".ascx", "")
                         .Replace("\\", "/")
                         .TrimStart('/');
@@ -701,14 +701,14 @@ namespace Dnn.PersonaBar.Themes.Components
 
         internal static ThemeLevel GetThemeLevel(string themeFilePath)
         {
-            if (themeFilePath.Replace("\\", "/").IndexOf(Globals.HostPath.TrimStart('/'), StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger
-                || themeFilePath.StartsWith("[G]", StringComparison.InvariantCultureIgnoreCase))
+            if (themeFilePath.Replace("\\", "/").IndexOf(Globals.HostPath.TrimStart('/'), StringComparison.OrdinalIgnoreCase) > Null.NullInteger
+                || themeFilePath.StartsWith("[G]", StringComparison.OrdinalIgnoreCase))
             {
                 return ThemeLevel.Global;
             }
             else if ((PortalSettings.Current != null &&
-                        themeFilePath.Replace("\\", "/").IndexOf(PortalSettings.Current.HomeSystemDirectory.TrimStart('/'), StringComparison.InvariantCultureIgnoreCase) > Null.NullInteger)
-                        || themeFilePath.StartsWith("[S]", StringComparison.InvariantCultureIgnoreCase))
+                        themeFilePath.Replace("\\", "/").IndexOf(PortalSettings.Current.HomeSystemDirectory.TrimStart('/'), StringComparison.OrdinalIgnoreCase) > Null.NullInteger)
+                        || themeFilePath.StartsWith("[S]", StringComparison.OrdinalIgnoreCase))
             {
                 return ThemeLevel.SiteSystem;
             }

--- a/src/Modules/Manage/Dnn.PersonaBar.Themes/Services/ThemesController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Themes/Services/ThemesController.cs
@@ -92,7 +92,7 @@ namespace Dnn.PersonaBar.Themes.Services
             {
                 var theme = (type == ThemeType.Skin ? _controller.GetLayouts(PortalSettings, level)
                                                     : _controller.GetContainers(PortalSettings, level)
-                            ).FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase));
+                            ).FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase));
 
                 if (theme == null)
                 {
@@ -134,7 +134,7 @@ namespace Dnn.PersonaBar.Themes.Services
             {
                 var themeInfo = _controller.GetLayouts(PortalSettings, ThemeLevel.All)
                                     .FirstOrDefault(
-                                        t => t.PackageName.Equals(defaultTheme.ThemeName, StringComparison.InvariantCultureIgnoreCase)
+                                        t => t.PackageName.Equals(defaultTheme.ThemeName, StringComparison.OrdinalIgnoreCase)
                                                 && t.Level == defaultTheme.Level);
 
                 if (themeInfo == null)
@@ -310,7 +310,7 @@ namespace Dnn.PersonaBar.Themes.Services
                 var themeName = parseTheme.ThemeName;
 
                 var layout = _controller.GetLayouts(PortalSettings, ThemeLevel.All)
-                                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == parseTheme.Level);
+                                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == parseTheme.Level);
 
                 if (layout != null)
                 {
@@ -318,7 +318,7 @@ namespace Dnn.PersonaBar.Themes.Services
                 }
 
                 var container = _controller.GetContainers(PortalSettings, ThemeLevel.All)
-                                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.InvariantCultureIgnoreCase) && t.Level == parseTheme.Level);
+                                .FirstOrDefault(t => t.PackageName.Equals(themeName, StringComparison.OrdinalIgnoreCase) && t.Level == parseTheme.Level);
 
                 if (container != null)
                 {

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/UsersController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/UsersController.cs
@@ -333,7 +333,7 @@ namespace Dnn.PersonaBar.Users.Components
             var roles = RoleController.Instance.GetUserRoles(user, true);
             if (!string.IsNullOrEmpty(keyword))
             {
-                roles = roles.Where(u => u.FullName.StartsWith(keyword, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                roles = roles.Where(u => u.FullName.StartsWith(keyword, StringComparison.OrdinalIgnoreCase)).ToList();
             }
             total = roles.Count;
             pageSize = pageSize > 0 && pageSize < 500 ? pageSize : 500;

--- a/src/Modules/Settings/Dnn.PersonaBar.Connectors/Services/ConnectorsController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Connectors/Services/ConnectorsController.cs
@@ -98,7 +98,7 @@ namespace Dnn.PersonaBar.Connectors.Services
                     })
                         .Where(
                             c =>
-                                c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                                c.Name.Equals(name, StringComparison.OrdinalIgnoreCase)).ToList();
 
                 var connector = connectors.FirstOrDefault(c =>
                     (c.SupportsMultiple && (c.Id == id || string.IsNullOrEmpty(c.Id))) ||
@@ -179,7 +179,7 @@ namespace Dnn.PersonaBar.Connectors.Services
                     })
                         .Where(
                             c =>
-                                c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                                c.Name.Equals(name, StringComparison.OrdinalIgnoreCase)).ToList();
 
                 var connector =
                     connectors.FirstOrDefault(c => c.SupportsMultiple && c.Id == id);
@@ -217,7 +217,7 @@ namespace Dnn.PersonaBar.Connectors.Services
                     x.HasConfig(PortalSettings.PortalId);
                 }
             })
-                .FirstOrDefault(c => c.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase));
+                .FirstOrDefault(c => c.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
             if (connection == null)
             {
                 return Request.CreateResponse(HttpStatusCode.NotFound);

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/CreateModuleController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/CreateModuleController.cs
@@ -94,8 +94,8 @@ namespace Dnn.PersonaBar.Extensions.Components
             var uniqueName = true;
             foreach (var package in PackageController.Instance.GetExtensionPackages(Null.NullInteger))
             {
-                if (package.Name.Equals(createModuleDto.ModuleName, StringComparison.InvariantCultureIgnoreCase) 
-                    || package.FriendlyName.Equals(createModuleDto.ModuleName, StringComparison.InvariantCultureIgnoreCase))
+                if (package.Name.Equals(createModuleDto.ModuleName, StringComparison.OrdinalIgnoreCase) 
+                    || package.FriendlyName.Equals(createModuleDto.ModuleName, StringComparison.OrdinalIgnoreCase))
                 {
                     uniqueName = false;
                     break;
@@ -137,8 +137,8 @@ namespace Dnn.PersonaBar.Extensions.Components
                 var moduleControl = "DesktopModules/" + folder + "/" + createModuleDto.FileName;
 
                 var packageInfo = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p =>
-                                    p.Name.Equals(createModuleDto.ModuleName, StringComparison.InvariantCultureIgnoreCase)
-                                     || p.FriendlyName.Equals(createModuleDto.ModuleName, StringComparison.InvariantCultureIgnoreCase));
+                                    p.Name.Equals(createModuleDto.ModuleName, StringComparison.OrdinalIgnoreCase)
+                                     || p.FriendlyName.Equals(createModuleDto.ModuleName, StringComparison.OrdinalIgnoreCase));
                 if (packageInfo != null)
                 {
                     errorMessage = "NonuniqueName";

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/Editors/AuthSystemPackageEditor.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/Editors/AuthSystemPackageEditor.cs
@@ -164,7 +164,7 @@ namespace Dnn.PersonaBar.Extensions.Components.Editors
                         if (packageSettings.EditorActions.TryGetValue("appEnabled", out value)
                             && config.Enabled.ToString().ToUpperInvariant() != value.ToUpperInvariant())
                         {
-                            config.Enabled = "TRUE".Equals(value, StringComparison.InvariantCultureIgnoreCase);
+                            config.Enabled = "TRUE".Equals(value, StringComparison.OrdinalIgnoreCase);
                             dirty = true;
                         }
 

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/Editors/JsLibraryPackageEditor.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/Editors/JsLibraryPackageEditor.cs
@@ -18,7 +18,8 @@ namespace Dnn.PersonaBar.Extensions.Components.Editors
         public PackageInfoDto GetPackageDetail(int portalId, PackageInfo package)
         {
             var usedBy = PackageController.Instance.GetPackageDependencies(d => 
-                            d.PackageName == package.Name && d.Version <= package.Version).Select(d => d.PackageId);
+                            d.PackageName.Equals(package.Name, StringComparison.OrdinalIgnoreCase) &&
+                            d.Version <= package.Version).Select(d => d.PackageId);
 
             var usedByPackages = from p in PackageController.Instance.GetExtensionPackages(portalId)
                                  where usedBy.Contains(p.PackageID)

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/ExtensionsController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/ExtensionsController.cs
@@ -110,7 +110,7 @@ namespace Dnn.PersonaBar.Extensions.Components
                     if (portalId == Null.NullInteger)
                     {
                         typePackages = PackageController.Instance.GetExtensionPackages(
-                            Null.NullInteger, p => "Module".Equals(p.PackageType, StringComparison.InvariantCultureIgnoreCase)).ToList();
+                            Null.NullInteger, p => "Module".Equals(p.PackageType, StringComparison.OrdinalIgnoreCase)).ToList();
                     }
                     else
                     {

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/InstallController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Components/InstallController.cs
@@ -241,8 +241,8 @@ namespace Dnn.PersonaBar.Extensions.Components
             }
             if (installer.Packages.Count > 0)
             {
-                if (installer.Packages[0].Package.PackageType.Equals("CoreLanguagePack", StringComparison.InvariantCultureIgnoreCase)
-                        || installer.Packages[0].Package.PackageType.Equals("ExtensionLanguagePack", StringComparison.InvariantCultureIgnoreCase))
+                if (installer.Packages[0].Package.PackageType.Equals("CoreLanguagePack", StringComparison.OrdinalIgnoreCase)
+                        || installer.Packages[0].Package.PackageType.Equals("ExtensionLanguagePack", StringComparison.OrdinalIgnoreCase))
                 {
                     compact = true;
                 }

--- a/src/Modules/Settings/Dnn.PersonaBar.Prompt/Components/ModulesController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Prompt/Components/ModulesController.cs
@@ -176,9 +176,9 @@ namespace Dnn.PersonaBar.Prompt.Components
             var modules = ModuleController.Instance.GetModules(portalSettings.PortalId)
                     .Cast<ModuleInfo>().Where(ModulePermissionController.CanViewModule);
             if (!string.IsNullOrEmpty(moduleName))
-                modules = modules.Where(module => module.DesktopModule.ModuleName.IndexOf(moduleName, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                modules = modules.Where(module => module.DesktopModule.ModuleName.IndexOf(moduleName, StringComparison.OrdinalIgnoreCase) >= 0);
             if (!string.IsNullOrEmpty(moduleTitle))
-                modules = modules.Where(module => module.ModuleTitle.IndexOf(moduleTitle, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                modules = modules.Where(module => module.ModuleTitle.IndexOf(moduleTitle, StringComparison.OrdinalIgnoreCase) >= 0);
 
             //Return only deleted modules with matching criteria.
             if (pageId.HasValue && pageId.Value > 0)

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Utility.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Utility.cs
@@ -116,7 +116,7 @@ namespace Dnn.PersonaBar.Security.Components
                 var queryMatchingFiles =
                     from file in fileList
                     let fileText = GetFileText(file.FullName)
-                    where fileText.IndexOf(searchText, StringComparison.InvariantCultureIgnoreCase) > -1
+                    where fileText.IndexOf(searchText, StringComparison.OrdinalIgnoreCase) > -1
                     select file;
                 return queryMatchingFiles.Select(f => new
                 {
@@ -138,7 +138,7 @@ namespace Dnn.PersonaBar.Security.Components
         public static IEnumerable<string> FindUnexpectedExtensions()
         {
             var files = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.*", SearchOption.AllDirectories)
-            .Where(s => s.EndsWith(".asp", StringComparison.InvariantCultureIgnoreCase) || s.EndsWith(".php", StringComparison.InvariantCultureIgnoreCase));
+            .Where(s => s.EndsWith(".asp", StringComparison.OrdinalIgnoreCase) || s.EndsWith(".php", StringComparison.OrdinalIgnoreCase));
             return files;
         }
 
@@ -151,7 +151,7 @@ namespace Dnn.PersonaBar.Security.Components
             var files = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.*", SearchOption.AllDirectories)
             .Where(f =>
             {
-                if (Path.GetFileName(f)?.Equals("thumbs.db", StringComparison.InvariantCultureIgnoreCase) == true)
+                if (Path.GetFileName(f)?.Equals("thumbs.db", StringComparison.OrdinalIgnoreCase) == true)
                 {
                     return false;
                 }

--- a/src/Modules/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Seo/Services/SeoController.cs
@@ -487,7 +487,7 @@ namespace Dnn.PersonaBar.Seo.Services
             {
                 SitemapProvider editedProvider =
                     _controller.GetSitemapProviders()
-                        .FirstOrDefault(p => p.Name.Equals(request.Name, StringComparison.InvariantCultureIgnoreCase));
+                        .FirstOrDefault(p => p.Name.Equals(request.Name, StringComparison.OrdinalIgnoreCase));
 
                 if (editedProvider != null)
                 {

--- a/src/Modules/Settings/Dnn.PersonaBar.SiteSettings/Services/LanguagesController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.SiteSettings/Services/LanguagesController.cs
@@ -662,7 +662,7 @@ namespace Dnn.PersonaBar.SiteSettings.Services
         {
             var portal = PortalController.Instance.GetPortal(portalId);
             var portalSettings = new PortalSettings(portal);
-            return string.Equals(cultureCode, portalSettings.DefaultLanguage, StringComparison.InvariantCultureIgnoreCase);
+            return string.Equals(cultureCode, portalSettings.DefaultLanguage, StringComparison.OrdinalIgnoreCase);
         }
 
         private bool IsLanguageEnabled(int portalId, string cultureCode)

--- a/src/Modules/Settings/Dnn.PersonaBar.SiteSettings/Services/SiteSettingsController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.SiteSettings/Services/SiteSettingsController.cs
@@ -2601,7 +2601,7 @@ namespace Dnn.PersonaBar.SiteSettings.Services
                         //if the disable language is current language, should redirect to default language.
                         if (
                             request.Code.Equals(Thread.CurrentThread.CurrentUICulture.ToString(),
-                                StringComparison.InvariantCultureIgnoreCase) ||
+                                StringComparison.OrdinalIgnoreCase) ||
                             LocaleController.Instance.GetLocales(pid).Count == 1)
                         {
                             redirectUrl = Globals.NavigateURL(PortalSettings.ActiveTab.TabID,

--- a/src/Modules/Settings/Dnn.PersonaBar.SqlConsole/Services/SqlConsoleController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.SqlConsole/Services/SqlConsoleController.cs
@@ -79,7 +79,7 @@ namespace Dnn.PersonaBar.SqlConsole.Services
             if (query.QueryId <= 0)
             {
                 var saveQueries = _controller.GetQueries();
-                var saveQuery = saveQueries.FirstOrDefault(q => q.Name.Equals(query.Name, StringComparison.InvariantCultureIgnoreCase));
+                var saveQuery = saveQueries.FirstOrDefault(q => q.Name.Equals(query.Name, StringComparison.OrdinalIgnoreCase));
                 if (saveQuery != null)
                 {
                     query.QueryId = saveQuery.QueryId;

--- a/src/Modules/Settings/Dnn.PersonaBar.TaskScheduler/Components/TaskSchedulerController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.TaskScheduler/Components/TaskSchedulerController.cs
@@ -150,7 +150,7 @@ namespace Dnn.PersonaBar.TaskScheduler.Components
                     scheduleviews = SchedulingController.GetSchedule(serverName);
                 }
                 if (!string.IsNullOrEmpty(taskName))
-                    scheduleviews = scheduleviews.Where(item => item.FriendlyName.IndexOf(taskName, StringComparison.InvariantCultureIgnoreCase) >= 0);
+                    scheduleviews = scheduleviews.Where(item => item.FriendlyName.IndexOf(taskName, StringComparison.OrdinalIgnoreCase) >= 0);
                 if (enabled.HasValue)
                     scheduleviews = scheduleviews.Where(item => item.Enabled == enabled.Value);
 


### PR DESCRIPTION
Changes to use "OrdinalIgnoreCase" instead of "InvariantCultureIgnoreCase" was based on this:
https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings