### PR TITLE
DNN-10154 - fixed super users search issue

### DIFF
--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.dnn
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Dnn.PersonaBar.Users.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="5.0">
   <packages>
-    <package name="Dnn.PersonaBar.Users" type="PersonaBar" version="01.05.00">
+    <package name="Dnn.PersonaBar.Users" type="PersonaBar" version="01.06.00">
       <friendlyName>Dnn.PersonaBar.Users</friendlyName>
       <description></description>
       <iconFile>~/Images/icon-personabarapp-32px.png</iconFile>
@@ -56,6 +56,11 @@
               <path>Providers\DataProviders\SqlDataProvider</path>
               <name>01.05.00.SqlDataProvider</name>
               <version>01.05.00</version>
+            </script>
+            <script type="Install">
+              <path>Providers\DataProviders\SqlDataProvider</path>
+              <name>01.06.00.SqlDataProvider</name>
+              <version>01.06.00</version>
             </script>
             <script type="UnInstall">
               <path>Providers\DataProviders\SqlDataProvider</path>

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Providers/DataProviders/SqlDataProvider/01.06.00.SqlDataProvider
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Providers/DataProviders/SqlDataProvider/01.06.00.SqlDataProvider
@@ -1,0 +1,77 @@
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/*****                                                  *****/
+/*****                                                  *****/
+/***** Note: To manually execute this script you must   *****/
+/*****       perform a search and replace operation     *****/
+/*****       for {databaseOwner} and {objectQualifier}  *****/
+/*****                                                  *****/
+/************************************************************/
+
+/** DNN-10154 Added option to include super users in search result **/
+IF EXISTS (SELECT * FROM dbo.sysobjects where id = object_id(N'{databaseOwner}{objectQualifier}Personabar_GetUsers') and OBJECTPROPERTY(id, N'IsProcedure') = 1)
+	DROP PROCEDURE {databaseOwner}{objectQualifier}Personabar_GetUsers
+GO
+
+CREATE PROCEDURE {databaseOwner}{objectQualifier}Personabar_GetUsers (
+	@PortalId INT,
+	@SortColumn NVARCHAR(32),
+	@SortAscending BIT,
+    @PageIndex int = 0,
+    @PageSize int = 10,
+	@Keyword NVARCHAR(128),
+	@IncludeUnauthorized bit,
+	@IncludeDeleted bit,
+	@IncludeSuperUsers bit
+) AS
+BEGIN
+	SELECT COUNT(*) AS TotalRecords
+	FROM {databaseOwner}{objectQualifier}UserPortals UP WITH (NOLOCK)
+	INNER JOIN {databaseOwner}{objectQualifier}vw_Users U WITH (NOLOCK) ON UP.UserId = U.UserID AND (@IncludeSuperUsers = 1 or U.PortalId = @PortalId)
+	WHERE UP.PortalId = @PortalId
+	AND (@IncludeSuperUsers = 1 OR (@IncludeSuperUsers = 0 and U.IsSuperUser = 0))
+	AND (
+			(
+				IsNull(@Keyword, N'') != N'' 
+				AND (u.DisplayName LIKE @Keyword OR u.FirstName LIKE @Keyword OR u.LastName LIKE @Keyword OR u.Username LIKE @Keyword OR u.Email LIKE @Keyword)
+			) 
+			OR IsNull(@Keyword, N'') = N''
+		)
+	AND (@IncludeUnauthorized = 1 OR @IncludeSuperUsers = 1 or (@IncludeUnauthorized = 0 AND @IncludeSuperUsers = 0 AND U.Authorised = 1))
+	AND (@IncludeDeleted = 1 OR (@IncludeDeleted = 0 AND U.IsDeleted = 0))
+		
+	;WITH UsersCTE
+	AS
+	(	
+		SELECT U.UserID, U.Username, U.DisplayName, U.Email, U.CreatedOnDate, U.IsDeleted, U.Authorised,
+		ROW_NUMBER() OVER ( ORDER BY CASE WHEN @SortColumn = 'Joined' AND @SortAscending = 1 THEN U.UserID END ASC, 
+									 CASE WHEN @SortColumn = 'Joined' AND @SortAscending = 0 THEN U.UserID END DESC,
+									 CASE WHEN @SortColumn = 'Email' AND @SortAscending = 1 THEN U.Email END ASC, 
+									 CASE WHEN @SortColumn = 'Email' AND @SortAscending = 0 THEN U.Email END DESC,
+									 CASE WHEN @SortColumn = 'DisplayName' AND @SortAscending = 1 THEN U.DisplayName END ASC, 
+									 CASE WHEN @SortColumn = 'DisplayName' AND @SortAscending = 0 THEN U.DisplayName END DESC) AS RowNumber 
+		FROM {databaseOwner}{objectQualifier}vw_Users U WITH (NOLOCK)
+		INNER JOIN {databaseOwner}{objectQualifier}UserPortals UP WITH (NOLOCK)
+			ON U.UserID = UP.UserId
+			AND (@IncludeSuperUsers = 1 or U.PortalId = @PortalId)
+		WHERE UP.PortalId = @PortalId
+		AND (@IncludeSuperUsers = 1 OR (@IncludeSuperUsers = 0 and U.IsSuperUser = 0))
+		AND (
+				(
+					IsNull(@Keyword, N'') != N'' 
+					AND (u.DisplayName LIKE @Keyword OR u.FirstName LIKE @Keyword OR u.LastName LIKE @Keyword OR u.Username LIKE @Keyword OR u.Email LIKE @Keyword)
+				) 
+				OR IsNull(@Keyword, N'') = N''
+			)
+		AND (@IncludeUnauthorized = 1 OR @IncludeSuperUsers = 1 or (@IncludeUnauthorized = 0 AND @IncludeSuperUsers = 0 AND U.Authorised = 1))
+		AND (@IncludeDeleted = 1 OR (@IncludeDeleted = 0 AND U.IsDeleted = 0))
+	)
+	SELECT * FROM UsersCTE
+	WHERE	RowNumber BETWEEN (@PageIndex * @PageSize + 1) AND ((@PageIndex + 1) * @PageSize);
+END
+GO
+
+
+/************************************************************/
+/*****              SqlDataProvider                     *****/
+/************************************************************/


### PR DESCRIPTION
Added @IncludeSuperUsers parameter in Personabar_GetUsers stored procedure to include/exclude super users from search result.
Also Lucene search was always excluding super users from search. Now superuser keyword is added in NumericKeys only if user is no super user. 