### PR TITLE
DNN-10163 - AddLogSettings now returns 401 status if user has admin role

### DIFF
--- a/src/Modules/Manage/Dnn.PersonaBar.AdminLogs/Services/AdminLogsController.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.AdminLogs/Services/AdminLogsController.cs
@@ -412,6 +412,11 @@ namespace Dnn.PersonaBar.AdminLogs.Services
         {
             try
             {
+                var isAdmin = UserInfo.Roles.Contains(PortalSettings.AdministratorRoleName);
+                if (isAdmin)
+                {
+                    return Request.CreateResponse(HttpStatusCode.Unauthorized);
+                }
                 request.LogTypePortalID = UserInfo.IsSuperUser ? request.LogTypePortalID : PortalId.ToString();
 
                 var logTypeConfigInfo = JObject.FromObject(request).ToObject<LogTypeConfigInfo>();


### PR DESCRIPTION
AddLogSettings will return 401 http status code, if user has admin role.