### PR TITLE
DNN-10299: SECURITY: Admin Security settings issues for API level calls

### DIFF
--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/AuthProviderSupportedAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/AuthProviderSupportedAttribute.cs
@@ -27,7 +27,7 @@ using DotNetNuke.Services.Localization;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class AuthProviderSupportedAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -36,15 +36,15 @@ namespace Dnn.PersonaBar.Security.Attributes
 
             if (string.IsNullOrWhiteSpace(value.ToString()))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Constants.EmptyValue, Constants.LocalResourcesFile), propertyName));
             }
 
             var allAuthProviders = new SecurityController().GetAuthenticationProviders();
 
             if (!allAuthProviders.Contains(value))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), propertyName, value.ToString()));
-            }            
+                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid, Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
 
             return ValidationResult.Success;
         }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/AuthProviderSupportedAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/AuthProviderSupportedAttribute.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Linq;
+using System.ComponentModel.DataAnnotations;
+using Dnn.PersonaBar.Security.Components;
+using DotNetNuke.Services.Localization;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class AuthProviderSupportedAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+
+            if (string.IsNullOrWhiteSpace(value.ToString()))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            var allAuthProviders = new SecurityController().GetAuthenticationProviders();
+
+            if (!allAuthProviders.Contains(value))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }            
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/CultureCodeExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/CultureCodeExistAttribute.cs
@@ -27,7 +27,7 @@ using DotNetNuke.Entities.Portals;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class CultureCodeExistAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -36,14 +36,14 @@ namespace Dnn.PersonaBar.Security.Attributes
 
             if (string.IsNullOrWhiteSpace(value.ToString()))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text",Components.Constants.LocalResourcesFile),propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.EmptyValue, Components.Constants.LocalResourcesFile), propertyName));
             }
 
             var allLocales = LocaleController.Instance.GetLocales(PortalController.Instance.GetCurrentPortalSettings().PortalId);
 
-            if (!allLocales.Select(l=>l.Value.Code).Contains(value.ToString()))
+            if (!allLocales.Select(l => l.Value.Code.ToLowerInvariant()).Contains(value.ToString().ToLowerInvariant()))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text",Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             return ValidationResult.Success;

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/CultureCodeExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/CultureCodeExistAttribute.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Services.Localization;
+using System;
+using System.Linq;
+using System.ComponentModel.DataAnnotations;
+using DotNetNuke.Entities.Portals;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class CultureCodeExistAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+
+            if (string.IsNullOrWhiteSpace(value.ToString()))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text",Components.Constants.LocalResourcesFile),propertyName, value.ToString()));
+            }
+
+            var allLocales = LocaleController.Instance.GetLocales(PortalController.Instance.GetCurrentPortalSettings().PortalId);
+
+            if (!allLocales.Select(l=>l.Value.Code).Contains(value.ToString()))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text",Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFieldsAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFieldsAttribute.cs
@@ -1,0 +1,91 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Linq;
+using System.ComponentModel.DataAnnotations;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Services.Localization;
+using Dnn.PersonaBar.Security.Components;
+using DotNetNuke.Services.Registration;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class RegistrationFieldsAttribute : ValidationAttribute
+    {
+        public string RegistrationFormTypePropertyName { get; private set; }
+        public string RequireUniqueDisplayNamePropertyName { get; private set; }
+
+        public RegistrationFieldsAttribute(string registrationFormType, string requireUniqueDisplayName)
+        {
+            RegistrationFormTypePropertyName = registrationFormType;
+            RequireUniqueDisplayNamePropertyName = requireUniqueDisplayName;
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var registrationFormTypeValue = validationContext.ObjectType.GetProperty(RegistrationFormTypePropertyName).GetValue(validationContext.ObjectInstance, null).ToString();
+            int registrationFormType;
+
+            if (!Int32.TryParse(registrationFormTypeValue, out registrationFormType))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), "RegistrationFormType", registrationFormTypeValue));
+            }
+
+            if (registrationFormType == 1)
+            {
+                var registrationFields = value.ToString();
+                var registrationTokens = registrationFields.Split(',');
+                var portalId = PortalController.Instance.GetCurrentPortalSettings().PortalId;
+
+                foreach (var registrationField in registrationTokens)
+                {   
+                    if (!string.IsNullOrWhiteSpace(registrationField) && RegistrationProfileController.Instance.Search(portalId,registrationField).Count() == 0)
+                    {
+                        return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), validationContext.DisplayName, registrationField));
+                    }
+                }
+
+                if (!registrationFields.Contains("Email"))
+                {
+                    return new ValidationResult(Localization.GetString(Constants.NoEmail + ".Text", Constants.LocalResourcesFile));
+                }
+
+                bool requireUniqueDisplayName;
+                var requireUniqueDisplayNameValue = validationContext.ObjectType.GetProperty(RequireUniqueDisplayNamePropertyName).GetValue(validationContext.ObjectInstance, null).ToString();
+
+                if (!bool.TryParse(requireUniqueDisplayNameValue, out requireUniqueDisplayName))
+                {
+                    return new ValidationResult(string.Format(Localization.GetString(Constants.NotValid + ".Text", Constants.LocalResourcesFile), "RequireUniqueDisplayName", requireUniqueDisplayNameValue));
+                }
+
+                if (!registrationFields.Contains("DisplayName") && requireUniqueDisplayName)
+                {                    
+                    PortalController.UpdatePortalSetting(portalId, "Registration_RegistrationFormType", "0", false);
+                    return new ValidationResult(Localization.GetString(Constants.NoDisplayName + ".Text", Constants.LocalResourcesFile));
+                }
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFormTypeOptionAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFormTypeOptionAttribute.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Services.Localization;
+using System;
+using System.Linq;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class RegistrationFormTypeOption : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+            int registrationFormTypeId;
+
+            if (string.IsNullOrWhiteSpace(value.ToString()) || !Int32.TryParse(value.ToString(), out registrationFormTypeId))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            var allOptions = Helper.RegistrationSettingsHelper.GetRegistrationFormOptions();
+
+            if (!allOptions.Select(o => o.Value).Contains(registrationFormTypeId))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFormTypeOptionAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/RegistrationFormTypeOptionAttribute.cs
@@ -26,24 +26,30 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class RegistrationFormTypeOption : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
             var propertyName = validationContext.DisplayName;
+
+            if (string.IsNullOrWhiteSpace(value.ToString()))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.EmptyValue, Components.Constants.LocalResourcesFile), propertyName));
+            }
+
             int registrationFormTypeId;
 
-            if (string.IsNullOrWhiteSpace(value.ToString()) || !Int32.TryParse(value.ToString(), out registrationFormTypeId))
+            if (!Int32.TryParse(value.ToString(), out registrationFormTypeId))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             var allOptions = Helper.RegistrationSettingsHelper.GetRegistrationFormOptions();
 
             if (!allOptions.Select(o => o.Value).Contains(registrationFormTypeId))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             return ValidationResult.Success;

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/TabExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/TabExistAttribute.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Tabs;
+using DotNetNuke.Services.Localization;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class TabExistAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+            int tabId = Convert.ToInt32(value.ToString());
+
+            if ( tabId != -1)
+            {
+                var portalSetting = PortalController.Instance.GetCurrentPortalSettings();
+                var tab = TabController.Instance.GetTab(tabId, portalSetting.PortalId);
+
+                if (tab == null)
+                {
+                    return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile),propertyName, tabId));
+                }
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/TabExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/TabExistAttribute.cs
@@ -27,7 +27,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class TabExistAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -35,14 +35,24 @@ namespace Dnn.PersonaBar.Security.Attributes
             var propertyName = validationContext.DisplayName;
             int tabId = Convert.ToInt32(value.ToString());
 
-            if ( tabId != -1)
+            if (tabId != -1)
             {
                 var portalSetting = PortalController.Instance.GetCurrentPortalSettings();
                 var tab = TabController.Instance.GetTab(tabId, portalSetting.PortalId);
 
                 if (tab == null)
                 {
-                    return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile),propertyName, tabId));
+                    return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, tabId));
+                }
+
+                if (tab.DisableLink)
+                {
+                    return new ValidationResult(string.Format(Localization.GetString(Components.Constants.DisabledTab, Components.Constants.LocalResourcesFile), tabId));
+                }
+
+                if (tab.IsDeleted)
+                {
+                    return new ValidationResult(string.Format(Localization.GetString(Components.Constants.DeletedTab, Components.Constants.LocalResourcesFile), tabId));
                 }
             }
 

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserEmailAsUsernameAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserEmailAsUsernameAttribute.cs
@@ -26,7 +26,7 @@ using DotNetNuke.Services.Localization;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class UserEmailAsUsernameAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -34,9 +34,9 @@ namespace Dnn.PersonaBar.Security.Attributes
             var propertyName = validationContext.DisplayName;
             bool userEmailAsUsername;
 
-            if (!bool.TryParse(value.ToString(),out userEmailAsUsername))
+            if (!bool.TryParse(value.ToString(), out userEmailAsUsername))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             if (userEmailAsUsername && UserController.GetDuplicateEmailCount() > 0)

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserEmailAsUsernameAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserEmailAsUsernameAttribute.cs
@@ -1,0 +1,50 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using DotNetNuke.Entities.Users;
+using DotNetNuke.Services.Localization;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class UserEmailAsUsernameAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+            bool userEmailAsUsername;
+
+            if (!bool.TryParse(value.ToString(),out userEmailAsUsername))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            if (userEmailAsUsername && UserController.GetDuplicateEmailCount() > 0)
+            {
+                return new ValidationResult(Localization.GetString(Components.Constants.ContainsDuplicateAddresses, Components.Constants.LocalResourcesFile));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserExistAttribute.cs
@@ -1,0 +1,62 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Users;
+using DotNetNuke.Services.Localization;
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class UserExistAttribute : ValidationAttribute
+    {
+        public string[] RoleNames { get; set; }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+            int UserId;
+
+            if (Int32.TryParse(value.ToString(),out UserId))
+            {
+                var portalSetting = PortalController.Instance.GetCurrentPortalSettings();                
+                var user = UserController.Instance.GetUserById(portalSetting.PortalId, UserId);
+               
+                if (user != null)
+                {
+                    foreach (var roleName in RoleNames)
+                    {
+                        if (!user.IsInRole(roleName))
+                        {
+                            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.UserNotMemberOfRole + ".Text", Components.Constants.LocalResourcesFile), roleName));
+                        }
+                    }
+
+                    return ValidationResult.Success;
+                }
+            }
+
+            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName,value.ToString()));            
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserExistAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserExistAttribute.cs
@@ -27,7 +27,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class UserExistAttribute : ValidationAttribute
     {
         public string[] RoleNames { get; set; }
@@ -35,20 +35,20 @@ namespace Dnn.PersonaBar.Security.Attributes
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
             var propertyName = validationContext.DisplayName;
-            int UserId;
+            int userId;
 
-            if (Int32.TryParse(value.ToString(),out UserId))
+            if (Int32.TryParse(value.ToString(), out userId))
             {
-                var portalSetting = PortalController.Instance.GetCurrentPortalSettings();                
-                var user = UserController.Instance.GetUserById(portalSetting.PortalId, UserId);
-               
+                var portalSetting = PortalController.Instance.GetCurrentPortalSettings();
+                var user = UserController.Instance.GetUserById(portalSetting.PortalId, userId);
+
                 if (user != null)
                 {
                     foreach (var roleName in RoleNames)
                     {
                         if (!user.IsInRole(roleName))
                         {
-                            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.UserNotMemberOfRole + ".Text", Components.Constants.LocalResourcesFile), roleName));
+                            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.UserNotMemberOfRole, Components.Constants.LocalResourcesFile), roleName));
                         }
                     }
 
@@ -56,7 +56,7 @@ namespace Dnn.PersonaBar.Security.Attributes
                 }
             }
 
-            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName,value.ToString()));            
+            return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
         }
     }
 }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserRegistrationOptionAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserRegistrationOptionAttribute.cs
@@ -1,0 +1,52 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using System;
+using System.Linq;
+using DotNetNuke.Services.Localization;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dnn.PersonaBar.Security.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    class UserRegistrationOptionAttribute : ValidationAttribute
+    {
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var propertyName = validationContext.DisplayName;
+            int userRegistrationOptionId;
+
+            if (string.IsNullOrWhiteSpace(value.ToString()) || !Int32.TryParse(value.ToString(), out userRegistrationOptionId))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            var allOptions = Helper.RegistrationSettingsHelper.GetUserRegistrationOptions();
+
+            if (!allOptions.Select(o=>o.Value).Contains(userRegistrationOptionId))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserRegistrationOptionAttribute.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Attributes/UserRegistrationOptionAttribute.cs
@@ -26,7 +26,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Dnn.PersonaBar.Security.Attributes
 {
-    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Property)]
     class UserRegistrationOptionAttribute : ValidationAttribute
     {
         protected override ValidationResult IsValid(object value, ValidationContext validationContext)
@@ -34,16 +34,21 @@ namespace Dnn.PersonaBar.Security.Attributes
             var propertyName = validationContext.DisplayName;
             int userRegistrationOptionId;
 
-            if (string.IsNullOrWhiteSpace(value.ToString()) || !Int32.TryParse(value.ToString(), out userRegistrationOptionId))
+            if (string.IsNullOrWhiteSpace(value.ToString()))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.EmptyValue, Components.Constants.LocalResourcesFile), propertyName));
+            }
+
+            if (!Int32.TryParse(value.ToString(), out userRegistrationOptionId))
+            {
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             var allOptions = Helper.RegistrationSettingsHelper.GetUserRegistrationOptions();
 
-            if (!allOptions.Select(o=>o.Value).Contains(userRegistrationOptionId))
+            if (!allOptions.Select(o => o.Value).Contains(userRegistrationOptionId))
             {
-                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid + ".Text", Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
+                return new ValidationResult(string.Format(Localization.GetString(Components.Constants.NotValid, Components.Constants.LocalResourcesFile), propertyName, value.ToString()));
             }
 
             return ValidationResult.Success;

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Constants.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Constants.cs
@@ -13,9 +13,12 @@
         public const string RegistrationSettingsEdit = "REGISTRATION_SETTINGS_EDIT";
         public const string UserNotMemberOfRole = "UserNotMemberOfRole";
         public const string NotValid = "NotValid";
+        public const string EmptyValue = "Empty";
         public const string NoDisplayName = "NoDisplayName";
         public const string NoEmail = "NoEmail";
         public const string ContainsDuplicateAddresses = "ContainsDuplicateAddresses";
-        public const string LocalResourcesFile = "~/DesktopModules/admin/Dnn.PersonaBar/Modules/Dnn.Security/App_LocalResources/Security.resx";
+        public const string DeletedTab = "DeletedTab";
+        public const string DisabledTab = "DisabledTab";
+        public const string LocalResourcesFile = "~/DesktopModules/admin/Dnn.PersonaBar/Modules/Dnn.Security/App_LocalResources/Security.resx";        
     }
 }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Constants.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Components/Constants.cs
@@ -11,6 +11,11 @@
         public const string MemberManagementEdit = "MEMBER_MANAGEMENT_EDIT";
         public const string RegistrationSettingsView = "REGISTRATION_SETTINGS_VIEW";
         public const string RegistrationSettingsEdit = "REGISTRATION_SETTINGS_EDIT";
+        public const string UserNotMemberOfRole = "UserNotMemberOfRole";
+        public const string NotValid = "NotValid";
+        public const string NoDisplayName = "NoDisplayName";
+        public const string NoEmail = "NoEmail";
+        public const string ContainsDuplicateAddresses = "ContainsDuplicateAddresses";
         public const string LocalResourcesFile = "~/DesktopModules/admin/Dnn.PersonaBar/Modules/Dnn.Security/App_LocalResources/Security.resx";
     }
 }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.csproj
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Dnn.PersonaBar.Security.csproj
@@ -78,6 +78,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
@@ -102,6 +103,14 @@
     <Compile Include="..\..\..\SolutionInfo.cs">
       <Link>SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\AuthProviderSupportedAttribute.cs" />
+    <Compile Include="Attributes\CultureCodeExistAttribute.cs" />
+    <Compile Include="Attributes\RegistrationFieldsAttribute.cs" />
+    <Compile Include="Attributes\RegistrationFormTypeOptionAttribute.cs" />
+    <Compile Include="Attributes\TabExistAttribute.cs" />
+    <Compile Include="Attributes\UserEmailAsUsernameAttribute.cs" />
+    <Compile Include="Attributes\UserExistAttribute.cs" />
+    <Compile Include="Attributes\UserRegistrationOptionAttribute.cs" />
     <Compile Include="Components\AuditChecks.cs" />
     <Compile Include="Components\BusinessController.cs" />
     <Compile Include="Components\CheckResult.cs" />
@@ -122,6 +131,7 @@
     <Compile Include="Components\Checks\CheckUnexpectedExtensions.cs" />
     <Compile Include="Components\Checks\CheckViewstatemac.cs" />
     <Compile Include="Components\Constants.cs" />
+    <Compile Include="Helper\RegistrationSettingsHelper.cs" />
     <Compile Include="MenuControllers\SecurityMenuController.cs" />
     <Compile Include="Components\IAuditCheck.cs" />
     <Compile Include="Components\SecurityController.cs" />

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Helper/RegistrationSettingsHelper.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Helper/RegistrationSettingsHelper.cs
@@ -1,0 +1,48 @@
+﻿#region Copyright
+// 
+// DotNetNuke® - http://www.dotnetnuke.com
+// Copyright (c) 2002-2017
+// by DotNetNuke Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation 
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and 
+// to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions 
+// of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED 
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+// THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+// CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+// DEALINGS IN THE SOFTWARE.
+#endregion
+
+using DotNetNuke.Services.Localization;
+using System.Collections.Generic;
+
+namespace Dnn.PersonaBar.Security.Helper
+{
+    class RegistrationSettingsHelper
+    {
+        internal static List<KeyValuePair<string, int>> GetUserRegistrationOptions()
+        {
+            var userRegistrationOptions = new List<KeyValuePair<string, int>>();
+            userRegistrationOptions.Add(new KeyValuePair<string, int>(Localization.GetString("None", Components.Constants.LocalResourcesFile), 0));
+            userRegistrationOptions.Add(new KeyValuePair<string, int>(Localization.GetString("Private", Components.Constants.LocalResourcesFile), 1));
+            userRegistrationOptions.Add(new KeyValuePair<string, int>(Localization.GetString("Public", Components.Constants.LocalResourcesFile), 2));
+            userRegistrationOptions.Add(new KeyValuePair<string, int>(Localization.GetString("Verified", Components.Constants.LocalResourcesFile), 3));
+            return userRegistrationOptions;
+        }
+
+        internal static List<KeyValuePair<string, int>> GetRegistrationFormOptions()
+        {
+            var registrationFormTypeOptions = new List<KeyValuePair<string, int>>();
+            registrationFormTypeOptions.Add(new KeyValuePair<string, int>(Localization.GetString("Standard", Components.Constants.LocalResourcesFile), 0));
+            registrationFormTypeOptions.Add(new KeyValuePair<string, int>(Localization.GetString("Custom", Components.Constants.LocalResourcesFile), 1));
+            return registrationFormTypeOptions;
+        }
+
+    }
+}

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Services/Dto/UpdateBasicLoginSettingsRequest.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Services/Dto/UpdateBasicLoginSettingsRequest.cs
@@ -18,30 +18,26 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-#region Usings
 
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Runtime.Serialization;
-using DotNetNuke.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
-#endregion
+using Dnn.PersonaBar.Security.Attributes;
 
 namespace Dnn.PersonaBar.Security.Services.Dto
 {
     public class UpdateBasicLoginSettingsRequest
     {
+        [CultureCodeExist]
         public string CultureCode { get; set; }
 
+        [AuthProviderSupported]
         public string DefaultAuthProvider { get; set; }
 
+        [UserExist(RoleNames = new string[] { Library.Constants.AdminsRoleName })]
         public int PrimaryAdministratorId { get; set; }
 
+        [TabExist]
         public int RedirectAfterLoginTabId { get; set; }
 
+        [TabExist]
         public int RedirectAfterLogoutTabId { get; set; }
 
         public bool RequireValidProfileAtLogin { get; set; }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/Services/Dto/UpdateRegistrationSettingsRequest.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/Services/Dto/UpdateRegistrationSettingsRequest.cs
@@ -18,23 +18,14 @@
 // CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
 // DEALINGS IN THE SOFTWARE.
 #endregion
-#region Usings
 
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Runtime.Serialization;
-using DotNetNuke.ComponentModel.DataAnnotations;
-using DotNetNuke.Entities.Host;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-
-#endregion
+using Dnn.PersonaBar.Security.Attributes;
 
 namespace Dnn.PersonaBar.Security.Services.Dto
 {
     public class UpdateRegistrationSettingsRequest
     {
+        [UserRegistrationOption]
         public string UserRegistration { get; set; }
 
         public bool UseAuthenticationProviders { get; set; }
@@ -43,12 +34,15 @@ namespace Dnn.PersonaBar.Security.Services.Dto
 
         public bool UseProfanityFilter { get; set; }
 
+        [RegistrationFormTypeOption]
         public int RegistrationFormType { get; set; }
 
+        [RegistrationFields("RegistrationFormType", "RequireUniqueDisplayName")]
         public string RegistrationFields { get; set; }
 
         public bool RequireUniqueDisplayName { get; set; }
 
+        [UserEmailAsUsername]
         public bool UseEmailAsUsername { get; set; }
 
         public string DisplayNameFormat { get; set; }
@@ -65,6 +59,7 @@ namespace Dnn.PersonaBar.Security.Services.Dto
 
         public bool UseCaptchaRegister { get; set; }
 
+        [TabExist]
         public int RedirectAfterRegistrationTabId { get; set; }
 
         public bool EnableRegisterNotification { get; set; }

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
@@ -1133,6 +1133,15 @@
     <value>User not member of {0} role.</value>
   </data>
   <data name="NotValid.Text" xml:space="preserve">
-    <value>{0}  {1} is not valid.</value>
+    <value>{0} {1} is not valid.</value>
+  </data>
+  <data name="Empty.Text" xml:space="preserve">
+    <value>{0} should not be empty.</value>
+  </data>
+  <data name="DeletedTab.Text" xml:space="preserve">
+    <value>The tab with this id {0} is deleted.</value>
+  </data>
+  <data name="Disabled.Text" xml:space="preserve">
+    <value>The tab with this id {0} is disable.</value>
   </data>
 </root>

--- a/src/Modules/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
+++ b/src/Modules/Settings/Dnn.PersonaBar.Security/admin/personaBar/App_LocalResources/Security.resx
@@ -1129,4 +1129,10 @@
   <data name="CheckTelerikVulnerabilitySuccess.Text" xml:space="preserve">
     <value>Telerik Component already patched.</value>
   </data>
+  <data name="UserNotMemberOfRole.Text" xml:space="preserve">
+    <value>User not member of {0} role.</value>
+  </data>
+  <data name="NotValid.Text" xml:space="preserve">
+    <value>{0}  {1} is not valid.</value>
+  </data>
 </root>

--- a/src/NuGetPackages/NuGetPackages.csproj
+++ b/src/NuGetPackages/NuGetPackages.csproj
@@ -38,72 +38,56 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ClientDependency.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\ClientDependency.Core.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\ClientDependency.Core.dll</HintPath>
     </Reference>
     <Reference Include="Dnn.PersonaBar.Library, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Dnn.PersonaBar.Library.1.5.0.39\lib\net45\Dnn.PersonaBar.Library.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Dnn.PersonaBar.Library.1.5.0.75\lib\net45\Dnn.PersonaBar.Library.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Core.9.2.0.98\lib\net40\DotNetNuke.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Core.9.2.0.166\lib\net40\DotNetNuke.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.HttpModules, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\DotNetNuke.HttpModules.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.HttpModules, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\DotNetNuke.HttpModules.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Instrumentation, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Instrumentation.9.2.0.98\lib\net40\DotNetNuke.Instrumentation.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Instrumentation, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Instrumentation.9.2.0.166\lib\net40\DotNetNuke.Instrumentation.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.Log4Net, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Instrumentation.9.2.0.98\lib\net40\DotNetNuke.Log4Net.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Instrumentation.9.2.0.166\lib\net40\DotNetNuke.Log4Net.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Modules.DigitalAssets, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\DotNetNuke.Modules.DigitalAssets.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Modules.DigitalAssets, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\DotNetNuke.Modules.DigitalAssets.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.Tests.Data, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\DotNetNuke.Tests.Data.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\DotNetNuke.Tests.Data.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.Tests.Utilities, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\DotNetNuke.Tests.Utilities.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\DotNetNuke.Tests.Utilities.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Web, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.9.2.0.98\lib\net40\DotNetNuke.Web.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Web, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Web.9.2.0.166\lib\net40\DotNetNuke.Web.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Client, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.Client.9.2.0.98\lib\net40\DotNetNuke.Web.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Web.Client, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Web.Client.9.2.0.166\lib\net40\DotNetNuke.Web.Client.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Deprecated, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.Deprecated.9.2.0.98\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Web.Deprecated, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Web.Deprecated.9.2.0.166\lib\net40\DotNetNuke.Web.Deprecated.dll</HintPath>
     </Reference>
-    <Reference Include="DotNetNuke.Web.Mvc, Version=9.2.0.98, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.Mvc.9.2.0.98\lib\net45\DotNetNuke.Web.Mvc.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DotNetNuke.Web.Mvc, Version=9.2.0.166, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetNuke.Web.Mvc.9.2.0.166\lib\net45\DotNetNuke.Web.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.WebControls, Version=2.4.0.598, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.98\lib\DotNetNuke.WebControls.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Bundle.9.2.0.166\lib\DotNetNuke.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="DotNetNuke.WebUtility, Version=4.2.1.783, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.9.2.0.98\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Web.9.2.0.166\lib\net40\DotNetNuke.WebUtility.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.ApplicationBlocks.Data, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Core.9.2.0.98\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Core.9.2.0.166\lib\net40\Microsoft.ApplicationBlocks.Data.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -144,8 +128,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Telerik.Web.UI, Version=2013.2.717.40, Culture=neutral, PublicKeyToken=121fae78165ba3d4, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetNuke.Web.Deprecated.9.2.0.98\lib\net40\Telerik.Web.UI.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\DotNetNuke.Web.Deprecated.9.2.0.166\lib\net40\Telerik.Web.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGetPackages/packages.config
+++ b/src/NuGetPackages/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dnn.PersonaBar.Library" version="1.5.0.39" targetFramework="net45" allowedVersions="[1.5.0, 1.5.1)" />
-  <package id="DotNetNuke.Bundle" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Core" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Instrumentation" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Web" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Web.Client" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Web.Deprecated" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.Web.Mvc" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
-  <package id="DotNetNuke.WebApi" version="9.2.0.98" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="Dnn.PersonaBar.Library" version="1.5.0.75" targetFramework="net45" allowedVersions="[1.5.0, 1.5.1)" />
+  <package id="DotNetNuke.Bundle" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Core" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Instrumentation" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Web" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Web.Client" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Web.Deprecated" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.Web.Mvc" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
+  <package id="DotNetNuke.WebApi" version="9.2.0.166" targetFramework="net45" allowedVersions="[9.2.0, 9.2.1)" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" allowedVersions="[5.2.3]" />


### PR DESCRIPTION
- Validation added by attribute filter so that It could be used prior to Model objects on both UpdateRegistrationSettingsRequest & UpdateBasicLoginSettingsRequest
- Localization messages are also added with format "{0}  {1} is not valid." i.e. if wrong culturecode added like pkr then it would be "Culturecode pkr is not valid."
- Nuget Package settings are also added so that it could be compilable
- Please give feedback on location of new classes added regarding folder used
- Though these validations are added for API calls but also applicable for application frontend
- Hard coded logics were also moved to separate helper class namely RegistrationSettingsHelper so that can be used for validation logic
