### PR TITLE
DNN-10583: Support for portal id in web api method

### DIFF
--- a/src/Modules/Settings/Dnn.PersonaBar.Prompt/Services/CommandController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Prompt/Services/CommandController.cs
@@ -27,36 +27,36 @@ namespace Dnn.PersonaBar.Prompt.Services
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(CommandController));
         private static readonly string[] BlackList = { "smtppassword", "password", "pwd", "pass", "apikey" };
 
-        private int portalId = -1;
+        private int _portalId = -1;
         private new int PortalId
         {
             get
             {
-                if (portalId == -1)
+                if (_portalId == -1)
                 {
-                    portalId = base.PortalId;
+                    _portalId = base.PortalId;
                 }
-                return portalId;
+                return _portalId;
             }
             set
             {
-                portalId = value;
+                _portalId = value;
             }
         }
-        private PortalSettings portalSettings;
+        private PortalSettings _portalSettings;
         private new PortalSettings PortalSettings
         {
             get
             {
-                if (portalSettings == null)
+                if (_portalSettings == null)
                 {
-                    portalSettings = base.PortalSettings;
+                    _portalSettings = base.PortalSettings;
                 }
-                return portalSettings;
+                return _portalSettings;
             }
             set
             {
-                portalSettings = value;
+                _portalSettings = value;
             }
         }
 


### PR DESCRIPTION
Currently the WebAPI endpoint is protected to allow host users only. It makes sense that the endpoint will allow hosts to run commands against other portals then the one currently being used. This will help us create more powerful possibilities in the future with the powershell connector.