### PR TITLE
Dnn-10735: Prompt: In case of across-portal scripting, sending invali…

### DIFF
--- a/src/Modules/Settings/Dnn.PersonaBar.Prompt/Services/CommandController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Prompt/Services/CommandController.cs
@@ -64,6 +64,15 @@ namespace Dnn.PersonaBar.Prompt.Services
         [HttpPost]
         public HttpResponseMessage Cmd(int portalId, [FromBody] CommandInputModel command)
         {
+            PortalId = portalId;
+            var portal = PortalController.Instance.GetPortal(PortalId);
+            if (portal == null)
+            {
+                var errorMessage = string.Format(Localization.GetString("Prompt_GetPortal_NotFound", Constants.LocalResourcesFile), portalId);
+                Logger.Error(errorMessage);
+                return AddLogAndReturnResponse(null, null, command, DateTime.Now, errorMessage);
+            }
+
             if (portalId != base.PortalId)
             {
                 if (!PortalHelper.IsRequestForSiteGroup(portalId, base.PortalSettings.PortalId))
@@ -72,8 +81,6 @@ namespace Dnn.PersonaBar.Prompt.Services
                     Logger.Error(errorMessage);
                     return AddLogAndReturnResponse(null, null, command, DateTime.Now, errorMessage);
                 }
-                PortalId = portalId;
-                var portal = PortalController.Instance.GetPortal(PortalId);
                 PortalSettings = new PortalSettings(PortalId);
             }
             return Cmd(command);


### PR DESCRIPTION
…d portal Id in the API, responds with a message related to site groups which has nothing to do with the invalid portalID

- Check for not existing portal