### PR TITLE
dDNN-10681: Prompt: Across-portal scripting: "list-pages" always listi…

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/IPagesController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/IPagesController.cs
@@ -11,9 +11,9 @@ namespace Dnn.PersonaBar.Pages.Components
     {
         bool IsValidTabPath(TabInfo tab, string newTabPath, string newTabName, out string errorMessage);
 
-        IEnumerable<TabInfo> GetPageList(int parentId = -1, string searchKey = "", bool includeHidden = true, bool includeDeleted = false);
+        IEnumerable<TabInfo> GetPageList(PortalSettings portalSettings, int parentId = -1, string searchKey = "", bool includeHidden = true, bool includeDeleted = false);
 
-        IEnumerable<TabInfo> GetPageList(bool? deleted, string tabName, string tabTitle, string tabPath,
+        IEnumerable<TabInfo> GetPageList(PortalSettings portalSettings, bool? deleted, string tabName, string tabTitle, string tabPath,
             string tabSkin, bool? visible, int parentId, out int total, string searchKey = "", int pageIndex = -1, int pageSize = 10);
 
         IEnumerable<TabInfo> SearchPages(out int totalRecords, string searchKey = "", string pageType = "", string tags = "", string publishStatus = "",

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
@@ -305,9 +305,9 @@ namespace Dnn.PersonaBar.Pages.Components
             return false;
         }
 
-        public IEnumerable<TabInfo> GetPageList(int parentId = -1, string searchKey = "", bool includeHidden = true, bool includeDeleted = false)
+        public IEnumerable<TabInfo> GetPageList(PortalSettings settings, int parentId = -1, string searchKey = "", bool includeHidden = true, bool includeDeleted = false)
         {
-            var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
+            var portalSettings = settings ?? PortalController.Instance.GetCurrentPortalSettings();
             var adminTabId = portalSettings.AdminTabId;
 
             var tabs = TabController.GetPortalTabs(portalSettings.PortalId, adminTabId, false, includeHidden, includeDeleted, true);
@@ -323,12 +323,12 @@ namespace Dnn.PersonaBar.Pages.Components
             return pages;
         }
 
-        public IEnumerable<TabInfo> GetPageList(bool? deleted, string tabName, string tabTitle, string tabPath,
+        public IEnumerable<TabInfo> GetPageList(PortalSettings portalSettings, bool? deleted, string tabName, string tabTitle, string tabPath,
             string tabSkin, bool? visible, int parentId, out int total, string searchKey = "", int pageIndex = -1, int pageSize = 10)
         {
             pageIndex = pageIndex <= 0 ? 0 : pageIndex;
             pageSize = pageSize > 0 && pageSize <= 100 ? pageSize : 10;
-            var tabs = GetPageList(parentId, searchKey, true, deleted ?? false);
+            var tabs = GetPageList(portalSettings, parentId, searchKey, true, deleted ?? false);
             var finalList = new List<TabInfo>();
             if (deleted.HasValue)
                 tabs = tabs.Where(tab => tab.IsDeleted == deleted);

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/Prompt/Commands/ListPages.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/Prompt/Commands/ListPages.cs
@@ -71,7 +71,7 @@ namespace Dnn.PersonaBar.Pages.Components.Prompt.Commands
 
             var lstOut = new List<PageModelBase>();
             int total;
-            var lstTabs = PagesController.Instance.GetPageList(Deleted, PageName, PageTitle, PagePath, PageSkin, PageVisible, ParentId ?? -1, out total, string.Empty, Page > 0 ? Page - 1 : 0, max);
+            var lstTabs = PagesController.Instance.GetPageList(PortalSettings, Deleted, PageName, PageTitle, PagePath, PageSkin, PageVisible, ParentId ?? -1, out total, string.Empty, Page > 0 ? Page - 1 : 0, max);
             var totalPages = total / max + (total % max == 0 ? 0 : 1);
             var pageNo = Page > 0 ? Page : 1;
             lstOut.AddRange(lstTabs.Select(tab => new PageModelBase(tab)));

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Services/PagesController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Services/PagesController.cs
@@ -206,7 +206,7 @@ namespace Dnn.PersonaBar.Pages.Services
         {
             var adminTabId = PortalSettings.AdminTabId;
             var tabs = TabController.GetPortalTabs(PortalSettings.PortalId, adminTabId, false, true, false, true);
-            var pages = from p in _pagesController.GetPageList(parentId, searchKey)
+            var pages = from p in _pagesController.GetPageList(PortalSettings, parentId, searchKey)
                         select Converters.ConvertToPageItem<PageItem>(p, tabs);
             return Request.CreateResponse(HttpStatusCode.OK, pages);
         }


### PR DESCRIPTION
…ng pages for the main site even with a remote site id Or with the portal-Id specified not for an existing portal

- Passed portalSettings to return data against it