### PR TITLE
DNN-8332 include page id when failed to find module

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Components/Prompt/Commands/PurgeModule.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Components/Prompt/Commands/PurgeModule.cs
@@ -34,7 +34,7 @@ namespace Dnn.PersonaBar.Recyclebin.Components.Prompt.Commands
         {
             var module = ModuleController.Instance.GetModule(ModuleId, PageId, true);
             if (module == null)
-                return new ConsoleErrorResultModel(string.Format(LocalizeString("ModuleNotFound"), ModuleId));
+                return new ConsoleErrorResultModel(string.Format(LocalizeString("ModuleNotFound"), ModuleId, PageId));
             var modulesToPurge = new List<ModuleInfo> { module };
             var errors = new StringBuilder();
             RecyclebinController.Instance.DeleteModules(modulesToPurge, errors);

--- a/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Components/RecyclebinController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Recyclebin/Components/RecyclebinController.cs
@@ -134,7 +134,7 @@ namespace Dnn.PersonaBar.Recyclebin.Components
                     var moduleInfo = ModuleController.Instance.GetModule(mod.Id, mod.TabID, true);
                     if (moduleInfo == null)
                     {
-                        errors.AppendFormat(LocalizeString("ModuleNotFound"), mod.Id);
+                        errors.AppendFormat(LocalizeString("ModuleNotFound"), mod.Id, mod.TabID);
                     }
                     else
                     {
@@ -279,7 +279,7 @@ namespace Dnn.PersonaBar.Recyclebin.Components
             }
             else
             {
-                errorMessage = string.Format(LocalizeString("ModuleNotFound"), moduleId);
+                errorMessage = string.Format(LocalizeString("ModuleNotFound"), moduleId, tabId);
                 return false;
             }
             return true;

--- a/src/Modules/Content/Dnn.PersonaBar.Recyclebin/admin/personaBar/App_LocalResources/Recyclebin.resx
+++ b/src/Modules/Content/Dnn.PersonaBar.Recyclebin/admin/personaBar/App_LocalResources/Recyclebin.resx
@@ -271,7 +271,7 @@
     <value>The {0} is required. Please use the --{1} flag or pass it as the first argument after the command name\n</value>
   </data>
   <data name="ModuleNotFound.Text" xml:space="preserve">
-    <value>Module with id "{0}" not found.</value>
+    <value>Module with id "{0}" not found on page "{1}".</value>
   </data>
   <data name="Prompt_ModulePurgedSuccessfully.Text" xml:space="preserve">
     <value>Module with id "{0}" purged successfully.</value>


### PR DESCRIPTION
This particular message is only used a few time, and always where we have the PageId aka TabId available so I simply added it to the string format