### PR TITLE
DNN-19566: Set-page working regardless of the CrossPortalId specified…

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/IPagesController.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/IPagesController.cs
@@ -56,7 +56,7 @@ namespace Dnn.PersonaBar.Pages.Components
         void CopyPermissionsToDescendantPages(int pageId);
 
         IEnumerable<Url> GetPageUrls(int tabId);
-        PageSettings GetPageSettings(int pageId);
+        PageSettings GetPageSettings(int pageId, PortalSettings portalSettings = null);
         PageUrlResult CreateCustomUrl(SeoUrl dto);
         PageUrlResult UpdateCustomUrl(SeoUrl dto);
         PageUrlResult DeleteCustomUrl(UrlIdDto dto);

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/PagesControllerImpl.cs
@@ -987,9 +987,15 @@ namespace Dnn.PersonaBar.Pages.Components
             return _pageUrlsController.GetPageUrls(tab, portalId);
         }
 
-        public PageSettings GetPageSettings(int pageId)
+        public PageSettings GetPageSettings(int pageId, PortalSettings requestPortalSettings = null)
         {
-            var tab = GetPageDetails(pageId);
+            var tab = GetPageDetails(pageId);            
+
+            if (!PortalHelper.IsContentExistsForRequestedPortal(tab.PortalID, requestPortalSettings))
+            {
+                throw new PageNotFoundException();
+            }
+
             var portalSettings = PortalController.Instance.GetCurrentPortalSettings();
             var page = Converters.ConvertToPageSettings<PageSettings>(tab);
             page.Modules = GetModules(page.TabId).Select(Converters.ConvertToModuleItem);

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Components/Prompt/Commands/SetPage.cs
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Components/Prompt/Commands/SetPage.cs
@@ -69,7 +69,7 @@ namespace Dnn.PersonaBar.Pages.Components.Prompt.Commands
         {
             try
             {
-                var pageSettings = PagesController.Instance.GetPageSettings(PageId);
+                var pageSettings = PagesController.Instance.GetPageSettings(PageId, PortalSettings);
                 if (pageSettings == null)
                 {
                     return new ConsoleErrorResultModel(LocalizeString("PageNotFound"));


### PR DESCRIPTION
… as parameter

- Add optional parameter of PortalSettings, so that existing functionality should not break
- Make sure to user request PortalSetting if portalId is passed in REST request