### PR TITLE
DNN-20873:  delete-user not working across portals and for cross-port…

### DIFF
--- a/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/DeleteUserUnitTests.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/DeleteUserUnitTests.cs
@@ -1,0 +1,139 @@
+﻿using Dnn.PersonaBar.Library.Prompt.Models;
+using Dnn.PersonaBar.Users.Components;
+using Dnn.PersonaBar.Users.Components.Prompt.Commands;
+using DotNetNuke.Entities.Portals;
+using DotNetNuke.Entities.Users;
+using Moq;
+using NUnit.Framework;
+
+namespace Dnn.PersonaBar.Users.Tests
+{
+    [TestFixture]
+    public class DeleteUserUnitTests
+    {
+        private Mock<IUserValidator> _userValidatorMock;
+        private Mock<IUserControllerWrapper> _userControllerWrapperMock;
+
+        private PortalSettings _portalSettings;
+        private ConsoleErrorResultModel _errorResultModel;        
+
+        private int _testPortalId = 0;
+
+        [SetUp]
+        public void RunBeforeEveryTest()
+        {
+            _userValidatorMock = new Mock<IUserValidator>();
+            _userControllerWrapperMock = new Mock<IUserControllerWrapper>();
+
+            _portalSettings = new PortalSettings();
+            _portalSettings.PortalId = _testPortalId;
+            _errorResultModel = null;
+        }
+
+        [Test]
+        public void Run_DeleteValidUserId_ReturnSuccessResponse()
+        {
+            // Arrange          
+            int userId = 2;            
+
+            UserInfo userInfo = GetUser(userId, false);
+
+            _userValidatorMock.Setup(u => u.ValidateUser(userId, _portalSettings, null, out userInfo)).Returns(_errorResultModel);
+            _userValidatorMock
+                .Setup(u => u.ValidateUser(-1, _portalSettings, null, out userInfo))
+                .Returns(_errorResultModel);
+            _userControllerWrapperMock.Setup(u => u.DeleteUserAndClearCache(ref userInfo, false, false)).Returns(true);
+            _userControllerWrapperMock.Setup(u => u.GetUserById(_testPortalId, userId)).Returns(userInfo);
+
+            var command = SetupCommand(userId.ToString());
+
+            // Act
+            var result = command.Run();
+
+            // Assert
+            Assert.IsFalse(result.IsError);
+        }
+
+        [Test]
+        public void Run_DeleteAlreadyDeletedUser_ReturnErrorResponse()
+        {
+            // Arrange          
+            int userId = 2;
+           
+            UserInfo userInfo = GetUser(userId, true);
+
+            _userValidatorMock.Setup(u => u.ValidateUser(userId, _portalSettings, null, out userInfo)).Returns(_errorResultModel);
+
+            var command = SetupCommand(userId.ToString());
+
+            // Act
+            var result = command.Run();
+
+            // Assert
+            Assert.IsTrue(result.IsError);
+        }
+
+        [Test]
+        public void Run_DeleteUserFailed_ReturnErrorResponse()
+        {
+            // Arrange          
+            int userId = 2;            
+
+            UserInfo userInfo = GetUser(userId, false);
+
+            _userValidatorMock.Setup(u => u.ValidateUser(userId, _portalSettings, null, out userInfo)).Returns(_errorResultModel);
+            _userValidatorMock
+                .Setup(u => u.ValidateUser(-1, _portalSettings, null, out userInfo))
+                .Returns(_errorResultModel);
+            _userControllerWrapperMock.Setup(u => u.DeleteUserAndClearCache(ref userInfo, false, false)).Returns(false);
+           
+            var command = SetupCommand(userId.ToString());
+
+            // Act
+            var result = command.Run();
+
+            // Assert
+            Assert.IsTrue(result.IsError);
+        }
+
+        [Test]
+        public void Run_DeleteNullUserId_ReturnErrorResponse()
+        {
+            // Arrange        
+            _errorResultModel = new ConsoleErrorResultModel();
+            
+            UserInfo userinfo;
+            _userValidatorMock
+                .Setup(u => u.ValidateUser(-1, _portalSettings, null, out userinfo))
+                .Returns(_errorResultModel);
+
+            var command = SetupCommand(string.Empty);
+
+            // Act
+            var result = command.Run();
+
+            // Assert
+            Assert.IsTrue(result.IsError);
+        }
+
+        private DeleteUser SetupCommand(string userId)
+        {
+            var command = new DeleteUser(_userValidatorMock.Object, _userControllerWrapperMock.Object);
+            var args = new[] { "delete-user", userId };
+            command.Initialize(args, _portalSettings, null, -1);
+            return command;
+        }
+
+        private UserInfo GetUser(int userId, bool isDeleted)
+        {
+            UserInfo userInfo = new UserInfo();
+            var profile = new UserProfile();
+            profile.FirstName = "testUser";
+            userInfo.UserID = userId;
+            userInfo.Profile = profile;
+            userInfo.IsDeleted = isDeleted;
+            userInfo.PortalID = _testPortalId;
+            return userInfo;
+        }
+    }
+}

--- a/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/DeleteUserUnitTests.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/DeleteUserUnitTests.cs
@@ -1,10 +1,10 @@
-﻿using Dnn.PersonaBar.Library.Prompt.Models;
+﻿using Moq;
+using NUnit.Framework;
+using DotNetNuke.Entities.Users;
+using DotNetNuke.Entities.Portals;
 using Dnn.PersonaBar.Users.Components;
 using Dnn.PersonaBar.Users.Components.Prompt.Commands;
-using DotNetNuke.Entities.Portals;
-using DotNetNuke.Entities.Users;
-using Moq;
-using NUnit.Framework;
+using Dnn.PersonaBar.Library.Prompt.Models;
 
 namespace Dnn.PersonaBar.Users.Tests
 {

--- a/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users.Tests/Dnn.PersonaBar.Users.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\..\..\SolutionInfo.cs">
       <Link>SolutionInfo.cs</Link>
     </Compile>
+    <Compile Include="DeleteUserUnitTests.cs" />
     <Compile Include="GetUserUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SearchUsersBySearchTermTest.cs" />

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/IUserControllerWrapper.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/IUserControllerWrapper.cs
@@ -7,9 +7,10 @@ namespace Dnn.PersonaBar.Users.Components
 {
     public interface IUserControllerWrapper
     {
-        UserInfo GetUser(int value, PortalSettings portalSettings, UserInfo currentUserInfo, out KeyValuePair<HttpStatusCode, string> response);
+        UserInfo GetUser(int userId, PortalSettings portalSettings, UserInfo currentUserInfo, out KeyValuePair<HttpStatusCode, string> response);
         UserInfo GetUserById(int portalId, int userId);
         int? GetUsersByUserName(int portalId, string searchTerm, int pageIndex, int pageSize, ref int recCount, bool includeDeleted, bool isSuperUserOnly);
         int? GetUsersByEmail(int portalId, string searchTerm, int pageIndex, int pageSize, ref int recCount, bool includeDeleted, bool isSuperUserOnly);
+        bool DeleteUserAndClearCache(ref UserInfo userInfo, bool notify, bool deleteAdmin);
     }
 }

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
@@ -66,11 +66,11 @@ namespace Dnn.PersonaBar.Users.Components.Prompt.Commands
             // We must clear User cache or else, when the user is 'removed' (so it can't be restored), you 
             // will not be able to create a new user with the same username -- even though no user with that username
             // exists.
-            DotNetNuke.Common.Utilities.DataCache.ClearUserCache(PortalId, userInfo.Username);
+            DotNetNuke.Common.Utilities.DataCache.ClearUserCache(userInfo.PortalID, userInfo.Username);
             // attempt to retrieve the user from the dB
-            userInfo = UserController.GetUserById(PortalId, userInfo.UserID);
+            userInfo = UserController.GetUserById(userInfo.PortalID, userInfo.UserID);
             userModels = new List<UserModel> { new UserModel(userInfo) };
-            return new ConsoleResultModel(LocalizeString("UserDeleted")) { Data = userModels, Records = userModels.Count };
+            return new ConsoleResultModel(LocalizeString("UserDeleted")) { Data = userModels, Records = userModels.Count };            
         }
     }
 }

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
@@ -51,12 +51,14 @@ namespace Dnn.PersonaBar.Users.Components.Prompt.Commands
                 return errorResultModel;
             }
 
-            var userModels = new List<UserModel> { new UserModel(userInfo) };
+            var userModels = new List<UserModel> { new UserModel(userInfo) };            
 
             if (userInfo.IsDeleted)
             {
                 return new ConsoleErrorResultModel(LocalizeString("Prompt_UserAlreadyDeleted"));
             }
+
+            var validPortalId = userInfo.PortalID;
 
             if (!_userControllerWrapper.DeleteUserAndClearCache(ref userInfo, Notify, false))
             {
@@ -67,7 +69,7 @@ namespace Dnn.PersonaBar.Users.Components.Prompt.Commands
             }
 
             // attempt to retrieve the user from the dB 
-            userInfo = _userControllerWrapper.GetUserById(userInfo.PortalID, userInfo.UserID);
+            userInfo = _userControllerWrapper.GetUserById(validPortalId, userInfo.UserID);
             userModels = new List<UserModel> { new UserModel(userInfo) };
             return new ConsoleResultModel(LocalizeString("UserDeleted")) { Data = userModels, Records = userModels.Count };            
         }

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/Prompt/Commands/DeleteUser.cs
@@ -19,17 +19,19 @@ namespace Dnn.PersonaBar.Users.Components.Prompt.Commands
         private const string FlagNotify = "notify";
 
         private IUserValidator _userValidator;
+        private IUserControllerWrapper _userControllerWrapper;
 
         private int UserId { get; set; }
         private bool Notify { get; set; }
 
-        public DeleteUser() : this(new UserValidator())
+        public DeleteUser() : this(new UserValidator(), new UserControllerWrapper())
         {
         }
 
-        public DeleteUser(IUserValidator userValidator)
+        public DeleteUser(IUserValidator userValidator, IUserControllerWrapper userControllerWrapper)
         {
             this._userValidator = userValidator;
+            this._userControllerWrapper = userControllerWrapper;
         }
 
         public override void Init(string[] args, PortalSettings portalSettings, UserInfo userInfo, int activeTabId)
@@ -56,19 +58,16 @@ namespace Dnn.PersonaBar.Users.Components.Prompt.Commands
                 return new ConsoleErrorResultModel(LocalizeString("Prompt_UserAlreadyDeleted"));
             }
 
-            if (!UserController.DeleteUser(ref userInfo, Notify, false))
+            if (!_userControllerWrapper.DeleteUserAndClearCache(ref userInfo, Notify, false))
             {
                 return new ConsoleErrorResultModel(LocalizeString("Prompt_UserDeletionFailed"))
                 {
                     Data = userModels
                 };
             }
-            // We must clear User cache or else, when the user is 'removed' (so it can't be restored), you 
-            // will not be able to create a new user with the same username -- even though no user with that username
-            // exists.
-            DotNetNuke.Common.Utilities.DataCache.ClearUserCache(userInfo.PortalID, userInfo.Username);
-            // attempt to retrieve the user from the dB
-            userInfo = UserController.GetUserById(userInfo.PortalID, userInfo.UserID);
+
+            // attempt to retrieve the user from the dB 
+            userInfo = _userControllerWrapper.GetUserById(userInfo.PortalID, userInfo.UserID);
             userModels = new List<UserModel> { new UserModel(userInfo) };
             return new ConsoleResultModel(LocalizeString("UserDeleted")) { Data = userModels, Records = userModels.Count };            
         }

--- a/src/Modules/Manage/Dnn.PersonaBar.Users/Components/UserControllerWrapper.cs
+++ b/src/Modules/Manage/Dnn.PersonaBar.Users/Components/UserControllerWrapper.cs
@@ -3,6 +3,7 @@ using System.Net;
 using DotNetNuke.Entities.Portals;
 using DotNetNuke.Entities.Users;
 using System.Linq;
+using DotNetNuke.Common.Utilities;
 
 namespace Dnn.PersonaBar.Users.Components
 {
@@ -26,6 +27,21 @@ namespace Dnn.PersonaBar.Users.Components
         public int? GetUsersByUserName(int portalId, string searchTerm, int pageIndex, int pageSize, ref int recCount, bool includeDeleted, bool isSuperUserOnly)
         {
             return (UserController.GetUsersByUserName(portalId, searchTerm, pageIndex, pageSize, ref recCount, includeDeleted, isSuperUserOnly).ToArray().FirstOrDefault() as UserInfo)?.UserID;
+        }
+
+        public bool DeleteUserAndClearCache(ref UserInfo userInfo, bool notify, bool deleteAdmin)
+        {
+            bool isDeleted = UserController.DeleteUser(ref userInfo, notify, deleteAdmin);
+
+            if (isDeleted)
+            {
+                // We must clear User cache or else, when the user is 'removed' (so it can't be restored), you 
+                // will not be able to create a new user with the same username -- even though no user with that username
+                // exists.
+                DataCache.ClearUserCache(userInfo.PortalID, userInfo.Username);
+            }
+
+            return isDeleted;
         }
     }
 }


### PR DESCRIPTION
…als api calls working regardless of API calls

- API error seems to be fixed by Get-User work
- Mean while User fetched against wrong portalId was giving exception use correct portal Id of user 

fixes #544 