### PR TITLE
DNN-8197 Fixed missing style

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/PersonaBarPageTreeview.jsx
@@ -162,6 +162,7 @@ export class PersonaBarPageTreeview extends Component {
             index++;
 
             const style = item.canManagePage ? { "white-space": "nowrap", height: "28px", lineHeight: "35px", marginLeft: "15px" } : { height: "28px", marginLeft: "15px" };
+            const itemNameHidden = item.status == "Hidden" ? "item-name-hidden" : "";
             return (
                 <li id={`list-item-${item.name}-${item.id}`}>
                     <div className={item.onDragOverState && item.id !== draggedItem.id ? "dropZoneActive" : "dropZoneInactive"} >
@@ -185,7 +186,7 @@ export class PersonaBarPageTreeview extends Component {
                         <div style={style} className={this.getClassName(item)}>
                             <PersonaBarPageIcon iconType={item.pageType} selected={item.selected} />
                             <span
-                                className={`item-name`}
+                                className={`item-name ${itemNameHidden}`}
                                 onClick={e => item.canManagePage ? onSelection(item) : onNoPermissionSelection(item)}>
                                 { (item.tabId === 0) || (item.selected && selectedPageDirty) ? 
                                     (

--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/dnn-persona-bar-page-treeview/src/styles.less
@@ -72,6 +72,9 @@
             display: inline;
         }
     }
+    .item-name-hidden {
+        font-style: italic;
+    }
     svg:hover {
         fill: @alto;
     }


### PR DESCRIPTION
fixes #584

**Missing styles in 9.2 to notify user which pages are hidden/Disabled**

Steps: 
1. Login to 9.1 with Admin user
2. Go to pages
3. Hover cursor over 'Home' or 'Activity Feed' page
4. Observe the 1st Icon displayed.
5. Login to 9.2 with Admin user
6. Go to pages

**This is a code review to keep italic style for selected nodes in the Pages treeview.**