### PR TITLE
Extensions - Resource dropdown is not populated

### DIFF
--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
@@ -65,6 +65,7 @@ namespace Dnn.PersonaBar.Extensions.Services
     public class ExtensionsController : PersonaBarApiController
     {
         private static readonly ILog Logger = LoggerSource.Instance.GetLogger(typeof(ExtensionsController));
+        private static readonly Regex ManifestExensionsRegex = new Regex(@"dnn\d*$");
         private readonly Components.ExtensionsController _controller = new Components.ExtensionsController();
         private static readonly string[] SpecialModuleFolders = new[] { "mvc" };
         private const string AuthFailureMessage = "Authorization has been denied for this request.";
@@ -983,8 +984,7 @@ namespace Dnn.PersonaBar.Extensions.Services
                         files.AddRange(GetFiles(Globals.HostMapPath + "Templates\\", ".module.template"));
                         break;
                     case FileType.Manifest:
-                        var regex = new Regex(@"\.dnn(\d+)?$");
-                        files.AddRange(GetFiles(folder, "*.*").Where(f => regex.IsMatch(f)));
+                        files.AddRange(GetFiles(folder, "*.dnn*").Where(file => ManifestExensionsRegex.IsMatch(file)));
                         break;
                 }
 

--- a/src/Modules/Settings/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
+++ b/src/Modules/Settings/Dnn.PersonaBar.Extensions/Services/ExtensionsController.cs
@@ -29,6 +29,7 @@ using System.Net.Http.Formatting;
 using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -982,8 +983,8 @@ namespace Dnn.PersonaBar.Extensions.Services
                         files.AddRange(GetFiles(Globals.HostMapPath + "Templates\\", ".module.template"));
                         break;
                     case FileType.Manifest:
-                        files.AddRange(GetFiles(folder, "*.dnn"));
-                        files.AddRange(GetFiles(folder, "*.dnn5"));
+                        var regex = new Regex(@"\.dnn(\d+)?$");
+                        files.AddRange(GetFiles(folder, "*.*").Where(f => regex.IsMatch(f)));
                         break;
                 }
 


### PR DESCRIPTION
fixes #592 

### Steps
- Login to Evoq Engage 
- navigate to Settings>Extensions 
- Click on Create new module 
- Select Manifest from the dropdown 
- Add Owner Folder & Moldule Folder 
- Click on Resource

### Current
Resource dropdown is populated, no matter what combination of Owner Folder & Module folder are selected.  Therefore cannot create Manifest as Resource is required field

### Expected
List is displayed for all *.dnn and *.dnnVERSION_NUMBER files in the module folder.