### PR TITLE
Fixed SqlConsole table sorting for numeric values

### DIFF
--- a/src/Modules/Settings/Dnn.PersonaBar.SqlConsole/admin/personaBar/scripts/SqlConsole.js
+++ b/src/Modules/Settings/Dnn.PersonaBar.SqlConsole/admin/personaBar/scripts/SqlConsole.js
@@ -344,8 +344,9 @@ define(['jquery',
                 var sortType = table.sortType();
                 if (sortType !== 0) {
                     filterData.sort(function (left, right) {
-                        var leftData = left[table.sortColumn()];
-                        var rightData = right[table.sortColumn()];
+                        var sortColumn = table.sortColumn();
+                        var leftData = isFinite(left[sortColumn]) ? parseFloat(left[sortColumn]) : left[sortColumn];
+                        var rightData = isFinite(right[sortColumn]) ? parseFloat(right[sortColumn]) : right[sortColumn];
 
                         if (leftData && typeof leftData === "string") {
                             leftData = leftData.toLowerCase();


### PR DESCRIPTION
### Description
In PB -> Settings -> SqlConsole html table is not correctly sorted when data are numeric, since data are treated as strings. 

### Solution proposed
Optimistic conversion to float performed before to apply sorting

fixes #599