### PR TITLE
Fix: missing reference to CallCustomAction

### DIFF
--- a/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/App.jsx
+++ b/src/Modules/Content/Dnn.PersonaBar.Pages/Pages.Web/src/components/App.jsx
@@ -1612,6 +1612,7 @@ class App extends Component {
                                         onNoPermissionSelection={this.onNoPermissionSelection.bind(this)}
                                         pageInContextComponents={props.pageInContextComponents}
                                         NoPermissionSelectionPageId={this.noPermissionSelectionPageId}
+                                        CallCustomAction={this.CallCustomAction.bind(this)}
                                         enabled={!((selectedPage && selectedPage.tabId === 0) || inSearch)} />
                                 </div>
                                 <GridCell columnSize={760} type={"px"}>


### PR DESCRIPTION
### Description
Impossible to open Analytics from Pages treeview due to a missing reference to CallCustomAction method defined in parent component App.jsx

### Solution
CallCusotmAction method set as a property of PersonaBarPageTreeviewInteractor